### PR TITLE
Show logs in Slack on deploy and build failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,184 +1,9 @@
 {
-  "name": "@spring-team/my-flow",
+  "name": "@atomist/github-sdm",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@atomist/antlr": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@atomist/antlr/-/antlr-0.1.4.tgz",
-      "integrity": "sha512-u/WliyVsWAzvu6PATfgo+nXuySohCpax5HP/Wh2/53H3u2EQtU1rR4ILZUseQ1GneOaRxhUo7fsSQxkP3ia2yg==",
-      "requires": {
-        "@atomist/automation-client": "0.3.5",
-        "antlr4ts": "0.4.1-alpha.0",
-        "lodash": "4.17.4"
-      },
-      "dependencies": {
-        "@atomist/automation-client": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-0.3.5.tgz",
-          "integrity": "sha512-qnOwI0C26S3zWG7jMeTKB576lF2CFUFOeuZb5dxmAu/L1K9jN0JOsvMRUlIKVKifVsAr82eKZKYs11Ca7zg7qA==",
-          "requires": {
-            "@atomist/microgrammar": "0.7.0",
-            "@atomist/slack-messages": "0.12.1",
-            "@atomist/tree-path": "0.1.8",
-            "@typed/curry": "1.0.1",
-            "@types/continuation-local-storage": "3.2.1",
-            "@types/cors": "2.8.3",
-            "@types/graphql": "0.11.8",
-            "@types/helmet": "0.0.37",
-            "@types/ws": "3.2.1",
-            "@types/zen-observable": "0.5.3",
-            "apollo-cache-inmemory": "1.1.9",
-            "apollo-client": "2.2.5",
-            "apollo-link-http": "1.3.3",
-            "app-root-path": "2.0.1",
-            "async-exit-hook": "2.0.1",
-            "axios": "0.17.1",
-            "base-64": "0.1.0",
-            "body-parser": "1.18.2",
-            "child-process-promise": "2.2.1",
-            "config": "1.29.4",
-            "connect-ensure-login": "0.1.1",
-            "connect-flash": "0.1.1",
-            "continuation-local-storage": "3.2.1",
-            "cors": "2.8.4",
-            "express": "4.16.2",
-            "express-force-ssl": "0.3.2",
-            "express-session": "1.15.6",
-            "fs-extra": "4.0.2",
-            "github": "12.1.0",
-            "glob-stream": "6.1.0",
-            "graphql": "0.11.7",
-            "graphql-tag": "2.5.0",
-            "heapdump": "0.3.9",
-            "helmet": "3.11.0",
-            "inquirer": "4.0.2",
-            "isbinaryfile": "3.0.2",
-            "isomorphic-fetch": "2.2.1",
-            "json-stringify-safe": "5.0.1",
-            "lodash": "4.17.4",
-            "lru_map": "0.3.3",
-            "memorystore": "1.6.0",
-            "metrics": "0.1.14",
-            "minimatch": "3.0.4",
-            "mustache-express": "1.2.5",
-            "node": "8.9.4",
-            "node-cache": "4.1.1",
-            "openurl": "1.1.1",
-            "passport": "0.4.0",
-            "passport-github": "1.1.0",
-            "passport-http": "0.3.0",
-            "passport-http-bearer": "1.0.1",
-            "power-assert": "1.4.4",
-            "promise-retry": "1.1.1",
-            "proper-lockfile": "2.0.1",
-            "serialize-error": "2.1.0",
-            "shelljs": "0.7.8",
-            "stream-spigot": "3.0.6",
-            "tmp-promise": "1.0.4",
-            "utf8": "2.1.2",
-            "uuid": "3.1.0",
-            "winston": "2.4.0",
-            "ws": "3.3.3",
-            "yargs": "10.1.2"
-          }
-        },
-        "@types/graphql": {
-          "version": "0.11.8",
-          "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.11.8.tgz",
-          "integrity": "sha512-xGWx4kx9JKlqxDrZA12gw5qi2lvxPNLxnQQcoTXVX83MuGcXcpb7TADatGyGW51GaaXQOQTbjw3x4HuL3ULBaA=="
-        },
-        "@types/ws": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@types/ws/-/ws-3.2.1.tgz",
-          "integrity": "sha512-t5n0/iHoavnX1MqeYmKJgWc1W6yX4BXsNxQg7M5862RWrfN9S5k8yaWbDMGJSTCzbH7+q5QS8chjymd+ND9gMw==",
-          "requires": {
-            "@types/node": "8.9.2"
-          }
-        },
-        "axios": {
-          "version": "0.17.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-          "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
-          "requires": {
-            "follow-redirects": "1.4.1",
-            "is-buffer": "1.1.6"
-          }
-        },
-        "graphql": {
-          "version": "0.11.7",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.11.7.tgz",
-          "integrity": "sha512-x7uDjyz8Jx+QPbpCFCMQ8lltnQa4p4vSYHx6ADe8rVYRTdsyhCJbvSty5DAsLVmU6cGakl+r8HQYolKHxk/tiw==",
-          "requires": {
-            "iterall": "1.1.3"
-          }
-        },
-        "inquirer": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-4.0.2.tgz",
-          "integrity": "sha512-+f3qDNeZpkhFJ61NBA9jXDrGGhoQuqfEum9A681c9oHoIbGgVqjogKynjB/vNVP+nVu9w3FbFQ35c0ibU0MaIQ==",
-          "requires": {
-            "ansi-escapes": "3.0.0",
-            "chalk": "2.3.0",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "2.1.0",
-            "figures": "2.0.0",
-            "lodash": "4.17.4",
-            "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rx-lite": "4.0.8",
-            "rx-lite-aggregates": "4.0.8",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
-          }
-        },
-        "utf8": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
-          "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
-        },
-        "ws": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-          "requires": {
-            "async-limiter": "1.0.0",
-            "safe-buffer": "5.1.1",
-            "ultron": "1.1.1"
-          }
-        },
-        "yargs": {
-          "version": "10.1.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-          "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
-          "requires": {
-            "cliui": "4.0.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "8.1.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
-          "requires": {
-            "camelcase": "4.1.0"
-          }
-        }
-      }
-    },
     "@atomist/automation-client": {
       "version": "https://r.atomist.com/HyEsBggNvz",
       "integrity": "sha512-4LCu5uZ08ondZ1JdWMnxzU3HuS/3a2V5LT+anZdJv6x6rEbb/nMuPo89ifSaR1pbpL6oJrshdu6EaEw4aBFbcQ==",
@@ -295,11 +120,11 @@
       }
     },
     "@atomist/spring-automation": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@atomist/spring-automation/-/spring-automation-0.6.0.tgz",
-      "integrity": "sha512-PwxKgo0jvH2SOVGhZvAz/85105SqyQmqw/jJmtudppFgQmgryjC/oFMLnxeFt1OUP6flXm1vDlzQUo/HxFFA1Q==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@atomist/spring-automation/-/spring-automation-0.6.2.tgz",
+      "integrity": "sha512-XxMPNMATcCTcxofHU3fbYOlgdSuF4DJrfcDpZLKp+Wo3lSBboo3WUyjtTe/Zh33f1U+Y4sKqNisTLANk3dXLBA==",
       "requires": {
-        "@atomist/antlr": "0.1.4",
+        "@atomist/antlr": "0.2.0",
         "@atomist/automation-client": "0.6.6",
         "@atomist/microgrammar": "0.7.0",
         "@atomist/slack-messages": "0.12.1",
@@ -319,6 +144,16 @@
         "xml2js": "0.4.19"
       },
       "dependencies": {
+        "@atomist/antlr": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/@atomist/antlr/-/antlr-0.2.0.tgz",
+          "integrity": "sha512-UM76Knaans8ZYn/4aKWx/EVnLqsjsFqnDuaObC08A0o7sr+m7xeBt3LyWfB2jTfIjXFztKG02DA9sHtGspAI/Q==",
+          "requires": {
+            "@atomist/automation-client": "0.6.6",
+            "antlr4ts": "0.4.1-alpha.0",
+            "lodash": "4.17.4"
+          }
+        },
         "@atomist/automation-client": {
           "version": "0.6.6",
           "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-0.6.6.tgz",
@@ -354,7 +189,7 @@
             "glob-stream": "6.1.0",
             "graphql": "0.12.3",
             "graphql-code-generator": "0.8.14",
-            "graphql-tag": "2.7.3",
+            "graphql-tag": "2.8.0",
             "helmet": "3.11.0",
             "https-proxy-agent": "2.1.1",
             "inquirer": "4.0.2",
@@ -441,9 +276,9 @@
           }
         },
         "graphql-tag": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.7.3.tgz",
-          "integrity": "sha1-UEARKhtGIyhe8BfCUidvDeo38D8="
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.8.0.tgz",
+          "integrity": "sha1-Us3qB6hCFU7BGi6EDBG5d/m4Nc4="
         },
         "inquirer": {
           "version": "4.0.2",
@@ -1595,16 +1430,6 @@
         "os-homedir": "1.0.2"
       }
     },
-    "connect-ensure-login": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/connect-ensure-login/-/connect-ensure-login-0.1.1.tgz",
-      "integrity": "sha1-F03MUSQ7nqwj+NmCFa62aU4uihI="
-    },
-    "connect-flash": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/connect-flash/-/connect-flash-0.1.1.tgz",
-      "integrity": "sha1-2GMPJtlaf4UfmVax6MxnMvO2qjA="
-    },
     "constant-case": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
@@ -2329,26 +2154,6 @@
         }
       }
     },
-    "express-force-ssl": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/express-force-ssl/-/express-force-ssl-0.3.2.tgz",
-      "integrity": "sha1-AbK0mK5v0uQRUrIrV6Phc3c69n4=",
-      "requires": {
-        "lodash.assign": "3.2.0"
-      },
-      "dependencies": {
-        "lodash.assign": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-          "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-          "requires": {
-            "lodash._baseassign": "3.2.0",
-            "lodash._createassigner": "3.1.1",
-            "lodash.keys": "3.1.2"
-          }
-        }
-      }
-    },
     "express-session": {
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.15.6.tgz",
@@ -2514,6 +2319,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
       "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
+      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "jsonfile": "4.0.0",
@@ -2547,34 +2353,6 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "1.0.0"
-      }
-    },
-    "github": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/github/-/github-12.1.0.tgz",
-      "integrity": "sha512-HhWjhd/OATC4Hjj7xfGjGRtwWzo/fzTc55EkvsRatI9G6Vp47mVcdBIt1lQ56A9Qit/yVQRX1+M9jbWlcJvgug==",
-      "requires": {
-        "dotenv": "4.0.0",
-        "follow-redirects": "1.2.6",
-        "https-proxy-agent": "2.1.1",
-        "lodash": "4.17.4",
-        "mime": "2.2.0",
-        "netrc": "0.1.4"
-      },
-      "dependencies": {
-        "follow-redirects": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.6.tgz",
-          "integrity": "sha512-FrMqZ/FONtHnbqO651UPpfRUVukIEwJhXMfdr/JWAmrDbeYBu773b1J6gdWDyRIj4hvvzQEHoEOTrdR8o6KLYA==",
-          "requires": {
-            "debug": "3.1.0"
-          }
-        },
-        "mime": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.2.0.tgz",
-          "integrity": "sha512-0Qz9uF1ATtl8RKJG4VRfOymh7PyEor6NbrI/61lRfuRe4vx9SNATrvAeTj2EWVRKjEQGskrzWkJBBY5NbaVHIA=="
-        }
       }
     },
     "glob": {
@@ -2799,11 +2577,6 @@
         "no-case": "2.3.2",
         "upper-case": "1.1.3"
       }
-    },
-    "heapdump": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/heapdump/-/heapdump-0.3.9.tgz",
-      "integrity": "sha1-A8dOsN9dZ74Jgug0KbqcnSs7f3g="
     },
     "helmet": {
       "version": "3.11.0",
@@ -3316,79 +3089,15 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-    },
-    "lodash._bindcallback": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
-    },
-    "lodash._createassigner": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-      "requires": {
-        "lodash._bindcallback": "3.0.1",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash.restparam": "3.6.1"
-      }
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-    },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
-    },
     "lodash.reduce": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
       "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
-    },
-    "lodash.restparam": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
     },
     "logzio-nodejs": {
       "version": "0.4.10",
@@ -3461,15 +3170,6 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
         "mimic-fn": "1.2.0"
-      }
-    },
-    "memorystore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/memorystore/-/memorystore-1.6.0.tgz",
-      "integrity": "sha1-H7X7Xwsu3xrdGEkX6RjwlKn/NGU=",
-      "requires": {
-        "debug": "3.1.0",
-        "lru-cache": "4.1.1"
       }
     },
     "memorystream": {
@@ -3617,33 +3317,6 @@
       "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
       "integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E="
     },
-    "mustache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz",
-      "integrity": "sha1-QCj3d4sXcIpImTCm5SrDvKDaQdA="
-    },
-    "mustache-express": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/mustache-express/-/mustache-express-1.2.5.tgz",
-      "integrity": "sha1-FypIRFpd5crcnwV/apKkr8oHrhQ=",
-      "requires": {
-        "async": "0.2.10",
-        "lru-cache": "2.5.2",
-        "mustache": "2.3.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
-        },
-        "lru-cache": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz",
-          "integrity": "sha1-H92tk4quEmPOE4aAvhs/WRwKtBw="
-        }
-      }
-    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -3653,11 +3326,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
-    },
-    "netrc": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
-      "integrity": "sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ="
     },
     "no-case": {
       "version": "2.3.2",
@@ -3671,19 +3339,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.0.0.tgz",
       "integrity": "sha1-ICtIAhoMTL3i34DeFaF0Q8i0OYA="
-    },
-    "node": {
-      "version": "8.9.4",
-      "resolved": "https://registry.npmjs.org/node/-/node-8.9.4.tgz",
-      "integrity": "sha512-3/3EJFUgpaS9LpG6EbbdCKLzaXC5RmvBfRzzv/brvHauqoS9YIrxraAxrW2MkL5mviSGp5x9EHQxwFd9Fh8LnA==",
-      "requires": {
-        "node-bin-setup": "1.0.6"
-      }
-    },
-    "node-bin-setup": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.0.6.tgz",
-      "integrity": "sha512-uPIxXNis1CRbv1DwqAxkgBk5NFV3s7cMN/Gf556jSw6jBvV7ca4F9lRL/8cALcZecRibeqU+5dFYqFFmzv5a0Q=="
     },
     "node-cache": {
       "version": "4.1.1",
@@ -3762,11 +3417,6 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
-    "oauth": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
-      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
-    },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
@@ -3810,11 +3460,6 @@
       "requires": {
         "mimic-fn": "1.2.0"
       }
-    },
-    "openurl": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
-      "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c="
     },
     "optimist": {
       "version": "0.6.1",
@@ -3944,14 +3589,6 @@
         "pause": "0.0.1"
       }
     },
-    "passport-github": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/passport-github/-/passport-github-1.1.0.tgz",
-      "integrity": "sha1-jOHj/NYa11eOsd9ZWDnkrqEjVdQ=",
-      "requires": {
-        "passport-oauth2": "1.4.0"
-      }
-    },
     "passport-http": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/passport-http/-/passport-http-0.3.0.tgz",
@@ -3966,17 +3603,6 @@
       "integrity": "sha1-FHRp6jZp4qhMYWfvmdu3fh8AmKg=",
       "requires": {
         "passport-strategy": "1.0.0"
-      }
-    },
-    "passport-oauth2": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.4.0.tgz",
-      "integrity": "sha1-9i+BWDy+EmCb585vFguTlaJ7hq0=",
-      "requires": {
-        "oauth": "0.9.15",
-        "passport-strategy": "1.0.0",
-        "uid2": "0.0.3",
-        "utils-merge": "1.0.1"
       }
     },
     "passport-strategy": {
@@ -5243,11 +4869,6 @@
       "requires": {
         "random-bytes": "1.0.0"
       }
-    },
-    "uid2": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
     "ultron": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@atomist/automation-client": "https://r.atomist.com/HyEsBggNvz",
     "@atomist/slack-messages": "^0.12.1",
-    "@atomist/spring-automation": "^0.6.0",
+    "@atomist/spring-automation": "^0.6.2",
     "app-root-path": "^2.0.1",
     "artifactory-publisher": "^1.1.4",
     "strip-ansi": "^4.0.0",

--- a/src/handlers/commands/RetryDeploy.ts
+++ b/src/handlers/commands/RetryDeploy.ts
@@ -1,8 +1,8 @@
-import {Parameters} from "@atomist/automation-client/decorators";
 import {HandleCommand, MappedParameter, MappedParameters, Parameter, Secret, Secrets} from "@atomist/automation-client";
+import {Parameters} from "@atomist/automation-client/decorators";
 
 export interface EventWithCommand {
-    correspondingCommand?: () => HandleCommand
+    correspondingCommand?: () => HandleCommand;
 }
 
 @Parameters()
@@ -27,4 +27,3 @@ export class RetryDeployParameters {
     public channelName: string;
 
 }
-

--- a/src/handlers/commands/RetryDeploy.ts
+++ b/src/handlers/commands/RetryDeploy.ts
@@ -1,0 +1,30 @@
+import {Parameters} from "@atomist/automation-client/decorators";
+import {HandleCommand, MappedParameter, MappedParameters, Parameter, Secret, Secrets} from "@atomist/automation-client";
+
+export interface EventWithCommand {
+    correspondingCommand?: () => HandleCommand
+}
+
+@Parameters()
+export class RetryDeployParameters {
+
+    @Parameter()
+    public repo: string;
+
+    @Parameter()
+    public owner: string;
+
+    @Parameter()
+    public sha: string;
+
+    @Parameter()
+    public targetUrl: string;
+
+    @Secret(Secrets.UserToken)
+    public githubToken: string;
+
+    @MappedParameter(MappedParameters.SlackChannelName)
+    public channelName: string;
+
+}
+

--- a/src/handlers/events/delivery/artifact/local/LocalArtifactStore.ts
+++ b/src/handlers/events/delivery/artifact/local/LocalArtifactStore.ts
@@ -4,7 +4,7 @@ import { ArtifactStore, DeployableArtifact, StoredArtifact } from "../../Artifac
 import { AppInfo } from "../../deploy/Deployment";
 
 /**
- * Store the artifact on local desk, relying on in memory cache
+ * Store the artifact on local disk, relying on in memory cache
  */
 export class LocalArtifactStore implements ArtifactStore {
 
@@ -36,7 +36,7 @@ export class LocalArtifactStore implements ArtifactStore {
                 if (!storedArtifact) {
                     logger.error("No stored artifact for [%s]: Known=%s", url,
                         this.entries.map(e => e.url).join(","));
-                    return undefined;
+                    return Promise.reject(new Error("No artifact found"));
                 }
 
                 const targetUrl = storedArtifact.deploymentUnitUrl;

--- a/src/handlers/events/delivery/build/BuildOnScanSuccessStatus.ts
+++ b/src/handlers/events/delivery/build/BuildOnScanSuccessStatus.ts
@@ -18,10 +18,10 @@ import { GraphQL, HandlerResult, Secret, Secrets, Success } from "@atomist/autom
 import { EventFired, EventHandler, HandlerContext } from "@atomist/automation-client/Handlers";
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import { OnAnySuccessStatus } from "../../../../typings/types";
+import { addressChannelsFor } from "../../../commands/editors/toclient/addressChannels";
 import { StatusSuccessHandler } from "../../StatusSuccessHandler";
 import { currentPhaseIsStillPending, nothingFailed, Phases, previousPhaseSucceeded } from "../Phases";
 import { Builder } from "./Builder";
-import { addressChannelsFor } from "../../../commands/editors/toclient/addressChannels";
 
 /**
  * See a GitHub success status with context "scan" and trigger a build producing an artifact status

--- a/src/handlers/events/delivery/build/BuildOnScanSuccessStatus.ts
+++ b/src/handlers/events/delivery/build/BuildOnScanSuccessStatus.ts
@@ -21,6 +21,7 @@ import { OnAnySuccessStatus } from "../../../../typings/types";
 import { StatusSuccessHandler } from "../../StatusSuccessHandler";
 import { currentPhaseIsStillPending, nothingFailed, Phases, previousPhaseSucceeded } from "../Phases";
 import { Builder } from "./Builder";
+import { addressChannelsFor } from "../../../commands/editors/toclient/addressChannels";
 
 /**
  * See a GitHub success status with context "scan" and trigger a build producing an artifact status
@@ -61,7 +62,7 @@ export class BuildOnScanSuccessStatus implements StatusSuccessHandler {
         const id = new GitHubRepoRef(commit.repo.owner, commit.repo.name, commit.sha);
         const creds = {token: params.githubToken};
 
-        await params.builder.initiateBuild(creds, id, team);
+        await params.builder.initiateBuild(creds, id, addressChannelsFor(commit.repo, ctx), team);
         return Success;
     }
 }

--- a/src/handlers/events/delivery/build/Builder.ts
+++ b/src/handlers/events/delivery/build/Builder.ts
@@ -1,5 +1,6 @@
 import { ProjectOperationCredentials } from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
+import { AddressChannels } from "../../../commands/editors/toclient/addressChannels";
 
 /**
  * Responsible for initiating a build. Wherever the build runs,
@@ -9,6 +10,7 @@ export interface Builder {
 
     initiateBuild(creds: ProjectOperationCredentials,
                   id: RemoteRepoRef,
+                  ac: AddressChannels,
                   team: string): Promise<any>;
 
 }

--- a/src/handlers/events/delivery/build/local/LocalBuilder.ts
+++ b/src/handlers/events/delivery/build/local/LocalBuilder.ts
@@ -112,7 +112,7 @@ async function onExit(success: boolean,
             const interpretation = logInterpreter && logInterpreter(log.log);
             // The deployer might have information about the failure; report it in the channels
             if (interpretation) {
-                await reportFailureInterpretation(interpretation, log, rb.appInfo.id, ac);
+                await reportFailureInterpretation("build", interpretation, log, rb.appInfo.id, ac);
             }
             await updateAtomistLifecycle(rb, "FAILURE", "FINALIZED");
         }

--- a/src/handlers/events/delivery/build/local/LocalBuilder.ts
+++ b/src/handlers/events/delivery/build/local/LocalBuilder.ts
@@ -2,18 +2,18 @@ import { ProjectOperationCredentials } from "@atomist/automation-client/operatio
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import axios from "axios";
 import { Readable } from "stream";
+import { reportFailureInterpretation } from "../../../../../util/reportFailureInterpretation";
+import { AddressChannels } from "../../../../commands/editors/toclient/addressChannels";
 import { postLinkImageWebhook } from "../../../link/ImageLink";
 import { ArtifactStore } from "../../ArtifactStore";
 import { AppInfo } from "../../deploy/Deployment";
-import {
-    LinkableLogFactory, LinkablePersistentProgressLog, ProgressLog,
-    QueryableProgressLog
-} from "../../log/ProgressLog";
-import { Builder } from "../Builder";
 import EventEmitter = NodeJS.EventEmitter;
 import { InterpretedLog, LogInterpretation, LogInterpreter } from "../../log/InterpretedLog";
-import { reportFailureInterpretation } from "../../../../../util/reportFailureInterpretation";
-import { AddressChannels } from "../../../../commands/editors/toclient/addressChannels";
+import {
+    LinkableLogFactory, LinkablePersistentProgressLog, ProgressLog,
+    QueryableProgressLog,
+} from "../../log/ProgressLog";
+import { Builder } from "../Builder";
 
 export interface LocalBuildInProgress {
 

--- a/src/handlers/events/delivery/build/local/LocalBuilder.ts
+++ b/src/handlers/events/delivery/build/local/LocalBuilder.ts
@@ -103,13 +103,13 @@ async function onExit(success: boolean,
                       artifactStore: ArtifactStore,
                       log: LinkablePersistentProgressLog & QueryableProgressLog,
                       ac: AddressChannels,
-                      errorParser: LogInterpreter): Promise<any> {
+                      logInterpreter: LogInterpreter): Promise<any> {
     try {
         if (success) {
             await updateAtomistLifecycle(rb, "SUCCESS", "FINALIZED")
                 .then(id => linkArtifact(rb, team, artifactStore));
         } else {
-            const interpretation = errorParser && errorParser(log.log);
+            const interpretation = logInterpreter && logInterpreter(log.log);
             // The deployer might have information about the failure; report it in the channels
             if (interpretation) {
                 await reportFailureInterpretation(interpretation, log, rb.appInfo.id, ac);

--- a/src/handlers/events/delivery/build/local/maven/MavenBuilder.ts
+++ b/src/handlers/events/delivery/build/local/maven/MavenBuilder.ts
@@ -8,6 +8,7 @@ import { AppInfo } from "../../../deploy/Deployment";
 import { LinkableLogFactory, LinkablePersistentProgressLog } from "../../../log/ProgressLog";
 import { LocalBuilder, LocalBuildInProgress } from "../LocalBuilder";
 import { identification } from "./pomParser";
+import { InterpretedLog, LogInterpretation, LogInterpreter } from "../../../log/InterpretedLog";
 
 /**
  * Build with Maven in the local automation client.
@@ -17,7 +18,7 @@ import { identification } from "./pomParser";
  * vulnerability in builds of unrelated tenants getting at each others
  * artifacts.
  */
-export class MavenBuilder extends LocalBuilder {
+export class MavenBuilder extends LocalBuilder implements LogInterpretation {
 
     constructor(artifactStore: ArtifactStore, logFactory: LinkableLogFactory) {
         super(artifactStore, logFactory);
@@ -52,6 +53,17 @@ export class MavenBuilder extends LocalBuilder {
                         return rb;
                     });
             });
+    }
+
+    public logInterpreter(log: string): InterpretedLog | undefined {
+        const relevantPart = log.split("\n")
+            .filter(l => l.startsWith("[ERROR]"))
+            .join("\n");
+        return {
+            relevantPart,
+            message: "Maven errors",
+            includeFullLog: true,
+        };
     }
 
 }

--- a/src/handlers/events/delivery/build/local/maven/MavenBuilder.ts
+++ b/src/handlers/events/delivery/build/local/maven/MavenBuilder.ts
@@ -5,10 +5,10 @@ import { ChildProcess, spawn } from "child_process";
 import { Readable } from "stream";
 import { ArtifactStore } from "../../../ArtifactStore";
 import { AppInfo } from "../../../deploy/Deployment";
+import { InterpretedLog, LogInterpretation, LogInterpreter } from "../../../log/InterpretedLog";
 import { LinkableLogFactory, LinkablePersistentProgressLog } from "../../../log/ProgressLog";
 import { LocalBuilder, LocalBuildInProgress } from "../LocalBuilder";
 import { identification } from "./pomParser";
-import { InterpretedLog, LogInterpretation, LogInterpreter } from "../../../log/InterpretedLog";
 
 /**
  * Build with Maven in the local automation client.

--- a/src/handlers/events/delivery/deploy/DeployFromLocalOnFingerprint.ts
+++ b/src/handlers/events/delivery/deploy/DeployFromLocalOnFingerprint.ts
@@ -29,6 +29,7 @@ import { BuiltContext } from "../phases/core";
 import { deploy } from "./deploy";
 import { Deployer } from "./Deployer";
 import { TargetInfo } from "./Deployment";
+import { addressChannelsFor } from "../../../commands/editors/toclient/addressChannels";
 
 // TODO could make more common with other deployer...
 @EventHandler("Deploy linked artifact",
@@ -77,6 +78,9 @@ export class DeployFromLocalOnFingerprint<T extends TargetInfo> implements Handl
         return deploy(params.ourPhase, params.endpointPhase,
             id, params.githubToken,
             fingerprint.commit.image.imageName,
-            params.artifactStore, params.deployer, params.targeter);
+            params.artifactStore,
+            params.deployer,
+            params.targeter,
+            addressChannelsFor(commit.repo, ctx));
     }
 }

--- a/src/handlers/events/delivery/deploy/DeployFromLocalOnFingerprint.ts
+++ b/src/handlers/events/delivery/deploy/DeployFromLocalOnFingerprint.ts
@@ -17,6 +17,7 @@ import {
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import { OnDeployToProductionFingerprint } from "../../../../typings/types";
+import { addressChannelsFor } from "../../../commands/editors/toclient/addressChannels";
 import { ArtifactStore } from "../ArtifactStore";
 import {
     currentPhaseIsStillPending,
@@ -29,7 +30,6 @@ import { BuiltContext } from "../phases/core";
 import { deploy } from "./deploy";
 import { Deployer } from "./Deployer";
 import { TargetInfo } from "./Deployment";
-import { addressChannelsFor } from "../../../commands/editors/toclient/addressChannels";
 
 // TODO could make more common with other deployer...
 @EventHandler("Deploy linked artifact",

--- a/src/handlers/events/delivery/deploy/DeployFromLocalOnImageLinked.ts
+++ b/src/handlers/events/delivery/deploy/DeployFromLocalOnImageLinked.ts
@@ -31,6 +31,7 @@ import { BuiltContext } from "../phases/core";
 import { deploy } from "./deploy";
 import { Deployer } from "./Deployer";
 import { TargetInfo } from "./Deployment";
+import { addressChannelsFor } from "../../../commands/editors/toclient/addressChannels";
 
 /**
  * Deploy a published artifact identified in an ImageLinked event.
@@ -89,7 +90,11 @@ export class DeployFromLocalOnImageLinked<T extends TargetInfo> implements Handl
 
         const id = new GitHubRepoRef(commit.repo.owner, commit.repo.name, commit.sha);
         return deploy(params.ourPhase, params.endpointPhase,
-            id, params.githubToken, imageLinked.image.imageName,
-            params.artifactStore, params.deployer, params.targeter);
+            id, params.githubToken,
+            imageLinked.image.imageName,
+            params.artifactStore,
+            params.deployer,
+            params.targeter,
+            addressChannelsFor(commit.repo, ctx));
     }
 }

--- a/src/handlers/events/delivery/deploy/Deployer.ts
+++ b/src/handlers/events/delivery/deploy/Deployer.ts
@@ -3,6 +3,12 @@ import { DeployableArtifact } from "../ArtifactStore";
 import { QueryableProgressLog } from "../log/ProgressLog";
 import { Deployment, TargetInfo } from "./Deployment";
 
+export interface InterpretedLog {
+    relevantPart: string;
+    message: string;
+    includeFullLog?: boolean
+}
+
 export interface Deployer<T extends TargetInfo = TargetInfo> {
 
     /**
@@ -13,5 +19,7 @@ export interface Deployer<T extends TargetInfo = TargetInfo> {
     undeploy?(id: RemoteRepoRef): Promise<any>;
 
     deploy(ai: DeployableArtifact, ti: T, log: QueryableProgressLog): Promise<Deployment>;
+
+    errorParser?: (log: string) => InterpretedLog | undefined
 
 }

--- a/src/handlers/events/delivery/deploy/Deployer.ts
+++ b/src/handlers/events/delivery/deploy/Deployer.ts
@@ -4,9 +4,18 @@ import { QueryableProgressLog } from "../log/ProgressLog";
 import { Deployment, TargetInfo } from "./Deployment";
 
 export interface InterpretedLog {
+
+    /**
+     * Relevant part of log to display in UX, if we were able to identify it
+     */
     relevantPart: string;
+
     message: string;
-    includeFullLog?: boolean
+
+    /**
+     * Should the UX include the full log, or is it too long or ugly?
+     */
+    includeFullLog?: boolean;
 }
 
 export interface Deployer<T extends TargetInfo = TargetInfo> {
@@ -20,6 +29,6 @@ export interface Deployer<T extends TargetInfo = TargetInfo> {
 
     deploy(ai: DeployableArtifact, ti: T, log: QueryableProgressLog): Promise<Deployment>;
 
-    errorParser?: (log: string) => InterpretedLog | undefined
+    errorParser?(log: string): InterpretedLog | undefined;
 
 }

--- a/src/handlers/events/delivery/deploy/Deployer.ts
+++ b/src/handlers/events/delivery/deploy/Deployer.ts
@@ -2,23 +2,9 @@ import { RemoteRepoRef } from "@atomist/automation-client/operations/common/Repo
 import { DeployableArtifact } from "../ArtifactStore";
 import { QueryableProgressLog } from "../log/ProgressLog";
 import { Deployment, TargetInfo } from "./Deployment";
+import { LogInterpretation } from "../log/InterpretedLog";
 
-export interface InterpretedLog {
-
-    /**
-     * Relevant part of log to display in UX, if we were able to identify it
-     */
-    relevantPart: string;
-
-    message: string;
-
-    /**
-     * Should the UX include the full log, or is it too long or ugly?
-     */
-    includeFullLog?: boolean;
-}
-
-export interface Deployer<T extends TargetInfo = TargetInfo> {
+export interface Deployer<T extends TargetInfo = TargetInfo> extends LogInterpretation {
 
     /**
      * Implemented by deployers that don't sit on an infrastructure like Cloud Foundry
@@ -28,7 +14,5 @@ export interface Deployer<T extends TargetInfo = TargetInfo> {
     undeploy?(id: RemoteRepoRef): Promise<any>;
 
     deploy(ai: DeployableArtifact, ti: T, log: QueryableProgressLog): Promise<Deployment>;
-
-    errorParser?(log: string): InterpretedLog | undefined;
 
 }

--- a/src/handlers/events/delivery/deploy/Deployer.ts
+++ b/src/handlers/events/delivery/deploy/Deployer.ts
@@ -1,8 +1,8 @@
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import { DeployableArtifact } from "../ArtifactStore";
+import { LogInterpretation } from "../log/InterpretedLog";
 import { QueryableProgressLog } from "../log/ProgressLog";
 import { Deployment, TargetInfo } from "./Deployment";
-import { LogInterpretation } from "../log/InterpretedLog";
 
 export interface Deployer<T extends TargetInfo = TargetInfo> extends LogInterpretation {
 

--- a/src/handlers/events/delivery/deploy/deploy.ts
+++ b/src/handlers/events/delivery/deploy/deploy.ts
@@ -14,20 +14,19 @@
  * limitations under the License.
  */
 
-import {HandlerResult, logger} from "@atomist/automation-client";
-import {GitHubRepoRef} from "@atomist/automation-client/operations/common/GitHubRepoRef";
-import {RemoteRepoRef} from "@atomist/automation-client/operations/common/RepoId";
-import {StatusState} from "../../../../typings/types";
-import {createStatus} from "../../../commands/editors/toclient/ghub";
-import {ArtifactStore} from "../ArtifactStore";
-import {createLinkableProgressLog} from "../log/NaiveLinkablePersistentProgressLog";
-import {ConsoleProgressLog, LinkablePersistentProgressLog, MultiProgressLog, QueryableProgressLog, SavingProgressLog} from "../log/ProgressLog";
-import {GitHubStatusContext, PlannedPhase} from "../Phases";
-import {Deployer, InterpretedLog} from "./Deployer";
-import {TargetInfo} from "./Deployment";
-import {AddressChannels} from "../../../commands/editors/toclient/addressChannels";
-
-import * as slack from "@atomist/slack-messages/SlackMessages"
+import { HandlerResult, logger } from "@atomist/automation-client";
+import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
+import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
+import { StatusState } from "../../../../typings/types";
+import { createStatus } from "../../../commands/editors/toclient/ghub";
+import { ArtifactStore } from "../ArtifactStore";
+import { createLinkableProgressLog } from "../log/NaiveLinkablePersistentProgressLog";
+import { ConsoleProgressLog, MultiProgressLog, QueryableProgressLog, SavingProgressLog } from "../log/ProgressLog";
+import { GitHubStatusContext, PlannedPhase } from "../Phases";
+import { Deployer } from "./Deployer";
+import { TargetInfo } from "./Deployment";
+import { AddressChannels } from "../../../commands/editors/toclient/addressChannels";
+import { reportFailureInterpretation } from "../../../../util/reportFailureInterpretation";
 
 export async function deploy<T extends TargetInfo>(deployPhase: PlannedPhase,
                                                    endpointPhase: PlannedPhase,
@@ -69,7 +68,7 @@ export async function deploy<T extends TargetInfo>(deployPhase: PlannedPhase,
                 });
         }
     } catch (err) {
-        const interpretation: InterpretedLog = deployer.errorParser && deployer.errorParser(linkableLog.log);
+        const interpretation = deployer.logInterpreter && deployer.logInterpreter(linkableLog.log);
         // The deployer might have information about the failure; report it in the channels
         if (interpretation) {
             await reportFailureInterpretation(interpretation, linkableLog, id, ac);
@@ -81,28 +80,6 @@ export async function deploy<T extends TargetInfo>(deployPhase: PlannedPhase,
     }
 }
 
-async function reportFailureInterpretation(interpretation: InterpretedLog,
-                                           fullLog: LinkablePersistentProgressLog & QueryableProgressLog,
-                                           id: RemoteRepoRef,
-                                           ac: AddressChannels) {
-    await ac({
-        text: `Failed deploy of ${slack.url(`${id.url}/tree/${id.sha}`, id.sha.substr(0, 6))}`,
-        attachments: [{
-            title: interpretation.message || "Failure",
-            title_link: fullLog.url,
-            fallback: "relevant bits",
-            text: interpretation.relevantPart,
-            color: "#ff5050",
-        }]
-    });
-    if (interpretation.includeFullLog) {
-        await ac({
-            content: fullLog,
-            fileType: "text",
-            fileName: `deploy-failure-${id.sha}.log`,
-        } as any);
-    }
-}
 
 function setDeployStatus(token: string, id: GitHubRepoRef,
                          state: StatusState,

--- a/src/handlers/events/delivery/deploy/deploy.ts
+++ b/src/handlers/events/delivery/deploy/deploy.ts
@@ -71,7 +71,7 @@ export async function deploy<T extends TargetInfo>(deployPhase: PlannedPhase,
         const interpretation = deployer.logInterpreter && deployer.logInterpreter(linkableLog.log);
         // The deployer might have information about the failure; report it in the channels
         if (interpretation) {
-            await reportFailureInterpretation(interpretation, linkableLog, id, ac);
+            await reportFailureInterpretation("deploy", interpretation, linkableLog, id, ac);
         }
         return setDeployStatus(githubToken, id, "failure",
             deployPhase.context,

--- a/src/handlers/events/delivery/deploy/deploy.ts
+++ b/src/handlers/events/delivery/deploy/deploy.ts
@@ -17,7 +17,10 @@
 import {HandlerResult, logger, success} from "@atomist/automation-client";
 import {GitHubRepoRef} from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import {RemoteRepoRef} from "@atomist/automation-client/operations/common/RepoId";
+import {Action} from "@atomist/slack-messages";
 import {StatusState} from "../../../../typings/types";
+import {reportFailureInterpretation} from "../../../../util/reportFailureInterpretation";
+import {AddressChannels} from "../../../commands/editors/toclient/addressChannels";
 import {createStatus} from "../../../commands/editors/toclient/ghub";
 import {ArtifactStore} from "../ArtifactStore";
 import {createLinkableProgressLog} from "../log/NaiveLinkablePersistentProgressLog";
@@ -25,25 +28,22 @@ import {ConsoleProgressLog, MultiProgressLog, QueryableProgressLog, SavingProgre
 import {GitHubStatusContext, PlannedPhase} from "../Phases";
 import {Deployer} from "./Deployer";
 import {TargetInfo} from "./Deployment";
-import {AddressChannels} from "../../../commands/editors/toclient/addressChannels";
-import {reportFailureInterpretation} from "../../../../util/reportFailureInterpretation";
-import {Action} from "@atomist/slack-messages";
 
 export interface DeployParams<T extends TargetInfo> {
-    deployPhase: PlannedPhase,
-    endpointPhase: PlannedPhase,
-    id: GitHubRepoRef,
-    githubToken: string,
-    targetUrl: string,
-    artifactStore: ArtifactStore,
-    deployer: Deployer<T>,
-    targeter: (id: RemoteRepoRef) => T,
-    ac: AddressChannels,
-    retryButton?: Action
+    deployPhase: PlannedPhase;
+    endpointPhase: PlannedPhase;
+    id: GitHubRepoRef;
+    githubToken: string;
+    targetUrl: string;
+    artifactStore: ArtifactStore;
+    deployer: Deployer<T>;
+    targeter: (id: RemoteRepoRef) => T;
+    ac: AddressChannels;
+    retryButton?: Action;
 }
 
 function isDeployParams<T extends TargetInfo>(a: PlannedPhase | DeployParams<T>): a is DeployParams<T> {
-    return !!(a as DeployParams<T>).deployPhase
+    return !!(a as DeployParams<T>).deployPhase;
 }
 
 export async function deploy<T extends TargetInfo>(paramsOrDeployPhase: PlannedPhase | DeployParams<T>,
@@ -82,7 +82,7 @@ export async function deploy<T extends TargetInfo>(paramsOrDeployPhase: PlannedP
         const savingLog = new SavingProgressLog();
         const progressLog = new MultiProgressLog(ConsoleProgressLog, savingLog, linkableLog) as any as QueryableProgressLog;
 
-        const artifactCheckout = await artifactStore.checkout(targetUrl).catch((err) => {
+        const artifactCheckout = await artifactStore.checkout(targetUrl).catch(err => {
             console.log("Writing to progress log");
             progressLog.write("Error checking out artifact: " + err.message);
             return progressLog.close().then(() => Promise.reject(err));
@@ -118,7 +118,6 @@ export async function deploy<T extends TargetInfo>(paramsOrDeployPhase: PlannedP
             `Failed to ${deployPhase.name}`).then(success);
     }
 }
-
 
 function setDeployStatus(token: string, id: GitHubRepoRef,
                          state: StatusState,

--- a/src/handlers/events/delivery/deploy/local/maven/mavenDeployer.ts
+++ b/src/handlers/events/delivery/deploy/local/maven/mavenDeployer.ts
@@ -93,6 +93,16 @@ class MavenDeployer implements Deployer {
     }
 
     public logInterpreter(log: string): InterpretedLog | undefined {
+        const maybeFailedToStart = appFailedToStart(log);
+        if (maybeFailedToStart) {
+            return {
+                relevantPart: maybeFailedToStart,
+                message: "Application failed to start",
+                includeFullLog: false
+            }
+        }
+
+        // default to maven errors
         const relevantPart = log.split("\n")
             .filter(l => l.startsWith("[ERROR]"))
             .join("\n");
@@ -103,4 +113,14 @@ class MavenDeployer implements Deployer {
         };
     }
 
+}
+
+function appFailedToStart(log: string) {
+    const lines = log.split("\n");
+    const failedToStartLine = lines.indexOf("APPLICATION FAILED TO START");
+    if (failedToStartLine < 1) {
+        return undefined;
+    }
+    const likelyLines = lines.slice(failedToStartLine + 3, failedToStartLine + 10);
+    return likelyLines.join("\n");
 }

--- a/src/handlers/events/delivery/deploy/local/maven/mavenDeployer.ts
+++ b/src/handlers/events/delivery/deploy/local/maven/mavenDeployer.ts
@@ -92,7 +92,7 @@ class MavenDeployer implements Deployer {
         });
     }
 
-    public errorParser(log: string): InterpretedLog | undefined {
+    public logInterpreter(log: string): InterpretedLog | undefined {
         const relevantPart = log.split("\n")
             .filter(l => l.startsWith("[ERROR]"))
             .join("\n");

--- a/src/handlers/events/delivery/deploy/local/maven/mavenDeployer.ts
+++ b/src/handlers/events/delivery/deploy/local/maven/mavenDeployer.ts
@@ -2,10 +2,10 @@ import {logger} from "@atomist/automation-client";
 import {RemoteRepoRef} from "@atomist/automation-client/operations/common/RepoId";
 import {ChildProcess, spawn} from "child_process";
 import {DeployableArtifact} from "../../../ArtifactStore";
+import {InterpretedLog} from "../../../log/InterpretedLog";
 import {QueryableProgressLog} from "../../../log/ProgressLog";
 import {Deployer} from "../../Deployer";
 import {Deployment, TargetInfo} from "../../Deployment";
-import {InterpretedLog} from "../../../log/InterpretedLog";
 
 /**
  * Ports will be reused for the same app
@@ -103,8 +103,8 @@ class MavenDeployer implements Deployer {
             return {
                 relevantPart: maybeFailedToStart,
                 message: "Application failed to start",
-                includeFullLog: false
-            }
+                includeFullLog: false,
+            };
         }
 
         // default to maven errors
@@ -125,7 +125,7 @@ class MavenDeployer implements Deployer {
                 relevantPart: log,
                 message: "I lost the local cache. Please rebuild",
                 includeFullLog: false,
-            }
+            };
         }
 
         logger.info("Did not find anything to recognize in the log");

--- a/src/handlers/events/delivery/deploy/local/maven/mavenDeployer.ts
+++ b/src/handlers/events/delivery/deploy/local/maven/mavenDeployer.ts
@@ -83,6 +83,5 @@ export function mavenDeployer(baseUrl: string = "http://localhost"): Deployer {
             });
         },
 
-    }
-        ;
+    };
 }

--- a/src/handlers/events/delivery/deploy/local/maven/mavenDeployer.ts
+++ b/src/handlers/events/delivery/deploy/local/maven/mavenDeployer.ts
@@ -3,8 +3,9 @@ import { RemoteRepoRef } from "@atomist/automation-client/operations/common/Repo
 import { ChildProcess, spawn } from "child_process";
 import { DeployableArtifact } from "../../../ArtifactStore";
 import { QueryableProgressLog } from "../../../log/ProgressLog";
-import { Deployer, InterpretedLog } from "../../Deployer";
+import { Deployer } from "../../Deployer";
 import { Deployment, TargetInfo } from "../../Deployment";
+import { InterpretedLog } from "../../../log/InterpretedLog";
 
 /**
  * Ports will be reused for the same app

--- a/src/handlers/events/delivery/log/InterpretedLog.ts
+++ b/src/handlers/events/delivery/log/InterpretedLog.ts
@@ -1,0 +1,25 @@
+
+export interface InterpretedLog {
+
+    /**
+     * Relevant part of log to display in UX, if we were able to identify it
+     */
+    relevantPart: string;
+
+    message: string;
+
+    /**
+     * Should the UX include the full log, or is it too long or ugly?
+     */
+    includeFullLog?: boolean;
+}
+
+export type LogInterpreter = (log: string) => InterpretedLog | undefined;
+
+/**
+ * Implemented by types that have the ability to interpret the logs they generate
+ */
+export interface LogInterpretation {
+
+    logInterpreter?: LogInterpreter;
+}

--- a/src/handlers/events/delivery/log/NaiveLinkablePersistentProgressLog.ts
+++ b/src/handlers/events/delivery/log/NaiveLinkablePersistentProgressLog.ts
@@ -1,9 +1,9 @@
 
-import { LinkablePersistentProgressLog } from "./ProgressLog";
+import {LinkablePersistentProgressLog, QueryableProgressLog} from "./ProgressLog";
 
-class NaiveLinkablePersistentProgressLog implements LinkablePersistentProgressLog {
+class NaiveLinkablePersistentProgressLog implements LinkablePersistentProgressLog, QueryableProgressLog {
 
-    private log = "";
+    public log = "";
 
     constructor(public url: string) {}
 
@@ -24,7 +24,7 @@ class NaiveLinkablePersistentProgressLog implements LinkablePersistentProgressLo
 
 }
 
-export function createLinkableProgressLog(): Promise<LinkablePersistentProgressLog> {
+export function createLinkableProgressLog(): Promise<LinkablePersistentProgressLog & QueryableProgressLog> {
     const url = "http://foo.bar/" + new Date().getMilliseconds();
     return Promise.resolve(new NaiveLinkablePersistentProgressLog(url));
 }

--- a/src/handlers/events/delivery/log/ProgressLog.ts
+++ b/src/handlers/events/delivery/log/ProgressLog.ts
@@ -119,4 +119,4 @@ export interface LinkablePersistentProgressLog extends ProgressLog {
 
 }
 
-export type LinkableLogFactory = () => Promise<LinkablePersistentProgressLog>;
+export type LinkableLogFactory = () => Promise<LinkablePersistentProgressLog & QueryableProgressLog>;

--- a/src/sdm/AbstractSoftwareDeliveryMachine.ts
+++ b/src/sdm/AbstractSoftwareDeliveryMachine.ts
@@ -2,6 +2,7 @@ import { HandleCommand, HandleEvent } from "@atomist/automation-client";
 import { AnyProjectEditor } from "@atomist/automation-client/operations/edit/projectEditor";
 import { ProjectReviewer } from "@atomist/automation-client/operations/review/projectReviewer";
 import {Maker, toFactory} from "@atomist/automation-client/util/constructionUtils";
+import {EventWithCommand} from "../handlers/commands/RetryDeploy";
 import { SetStatusOnBuildComplete } from "../handlers/events/delivery/build/SetStatusOnBuildComplete";
 import { DeployListener, OnDeployStatus } from "../handlers/events/delivery/deploy/OnDeployStatus";
 import { FailDownstreamPhasesOnPhaseFailure } from "../handlers/events/delivery/FailDownstreamPhasesOnPhaseFailure";
@@ -27,7 +28,6 @@ import { StatusSuccessHandler } from "../handlers/events/StatusSuccessHandler";
 import { OnImageLinked } from "../typings/types";
 import { PromotedEnvironment } from "./ReferenceDeliveryBlueprint";
 import { SoftwareDeliveryMachine } from "./SoftwareDeliveryMachine";
-import {EventWithCommand} from "../handlers/commands/RetryDeploy";
 
 /**
  * Superclass for user software delivery machines
@@ -149,7 +149,7 @@ export abstract class AbstractSoftwareDeliveryMachine implements SoftwareDeliver
         return this.generators
             .concat(this.editors)
             .concat(this.supportingCommands)
-            .concat([mayHaveCommand.correspondingCommand ? () => mayHaveCommand.correspondingCommand(): undefined])
+            .concat([mayHaveCommand.correspondingCommand ? () => mayHaveCommand.correspondingCommand() : undefined])
             .concat([
                 !!this.promotedEnvironment ? this.promotedEnvironment.promote : undefined,
                 !!this.promotedEnvironment ? this.promotedEnvironment.offerPromotionCommand : undefined,

--- a/src/sdm/AbstractSoftwareDeliveryMachine.ts
+++ b/src/sdm/AbstractSoftwareDeliveryMachine.ts
@@ -1,7 +1,7 @@
 import { HandleCommand, HandleEvent } from "@atomist/automation-client";
 import { AnyProjectEditor } from "@atomist/automation-client/operations/edit/projectEditor";
 import { ProjectReviewer } from "@atomist/automation-client/operations/review/projectReviewer";
-import { Maker } from "@atomist/automation-client/util/constructionUtils";
+import {Maker, toFactory} from "@atomist/automation-client/util/constructionUtils";
 import { SetStatusOnBuildComplete } from "../handlers/events/delivery/build/SetStatusOnBuildComplete";
 import { DeployListener, OnDeployStatus } from "../handlers/events/delivery/deploy/OnDeployStatus";
 import { FailDownstreamPhasesOnPhaseFailure } from "../handlers/events/delivery/FailDownstreamPhasesOnPhaseFailure";
@@ -27,6 +27,7 @@ import { StatusSuccessHandler } from "../handlers/events/StatusSuccessHandler";
 import { OnImageLinked } from "../typings/types";
 import { PromotedEnvironment } from "./ReferenceDeliveryBlueprint";
 import { SoftwareDeliveryMachine } from "./SoftwareDeliveryMachine";
+import {EventWithCommand} from "../handlers/commands/RetryDeploy";
 
 /**
  * Superclass for user software delivery machines
@@ -100,7 +101,7 @@ export abstract class AbstractSoftwareDeliveryMachine implements SoftwareDeliver
 
     public abstract builder: Maker<StatusSuccessHandler>;
 
-    public abstract deploy1: Maker<HandleEvent<OnImageLinked.Subscription>>;
+    public abstract deploy1: Maker<HandleEvent<OnImageLinked.Subscription> & EventWithCommand>;
 
     public get notifyOnDeploy(): Maker<OnDeployStatus> {
         return this.deploymentListeners.length > 0 ?
@@ -144,9 +145,11 @@ export abstract class AbstractSoftwareDeliveryMachine implements SoftwareDeliver
     }
 
     get commandHandlers(): Array<Maker<HandleCommand>> {
+        const mayHaveCommand = toFactory(this.deploy1)();
         return this.generators
             .concat(this.editors)
             .concat(this.supportingCommands)
+            .concat([mayHaveCommand.correspondingCommand ? () => mayHaveCommand.correspondingCommand(): undefined])
             .concat([
                 !!this.promotedEnvironment ? this.promotedEnvironment.promote : undefined,
                 !!this.promotedEnvironment ? this.promotedEnvironment.offerPromotionCommand : undefined,

--- a/src/software-delivery-machine/SpringPCFSoftwareDeliveryMachine.ts
+++ b/src/software-delivery-machine/SpringPCFSoftwareDeliveryMachine.ts
@@ -30,7 +30,7 @@ import { logReactor, logReview } from "./blueprint/review/scan";
 import { addCloudFoundryManifest } from "./commands/editors/addCloudFoundryManifest";
 import { springBootGenerator } from "./commands/generators/spring/springBootGenerator";
 
-const Deploy1 = LocalMavenDeployOnImageLinked;
+const LocalMavenDeployer = LocalMavenDeployOnImageLinked;
 
 // CloudFoundryStagingDeployOnImageLinked
 
@@ -42,7 +42,7 @@ export class SpringPCFSoftwareDeliveryMachine extends AbstractSoftwareDeliveryMa
 
     public builder: Maker<StatusSuccessHandler> = LocalMavenBuildOnSucessStatus;
 
-    public deploy1: Maker<HandleEvent<OnImageLinked.Subscription>> = () => Deploy1;
+    public deploy1: Maker<HandleEvent<OnImageLinked.Subscription>> = () => LocalMavenDeployer;
 
     public verifyEndpoint: Maker<VerifyOnEndpointStatus> = LookFor200OnEndpointRootGet;
 
@@ -93,7 +93,7 @@ export class SpringPCFSoftwareDeliveryMachine extends AbstractSoftwareDeliveryMa
             .addSupersededListeners(
                 id => {
                     logger.info("Will undeploy application %j", id);
-                    return Deploy1.deployer.undeploy(id);
+                    return LocalMavenDeployer.deployer.undeploy(id);
                 });
     }
 }

--- a/src/util/reportFailureInterpretation.ts
+++ b/src/util/reportFailureInterpretation.ts
@@ -9,7 +9,8 @@ export async function reportFailureInterpretation(stepName: string,
                                                   interpretation: InterpretedLog,
                                                   fullLog: LinkablePersistentProgressLog & QueryableProgressLog,
                                                   id: RemoteRepoRef,
-                                                  ac: AddressChannels) {
+                                                  ac: AddressChannels,
+                                                  retryButton?: slack.Action) {
     await ac({
         text: `Failed ${stepName} of ${slack.url(`${id.url}/tree/${id.sha}`, id.sha.substr(0, 6))}`,
         attachments: [{
@@ -18,6 +19,7 @@ export async function reportFailureInterpretation(stepName: string,
             fallback: "relevant bits",
             text: interpretation.relevantPart,
             color: "#ff5050",
+            actions: retryButton? [retryButton] : []
         }],
     });
     if (interpretation.includeFullLog) {

--- a/src/util/reportFailureInterpretation.ts
+++ b/src/util/reportFailureInterpretation.ts
@@ -1,16 +1,17 @@
-import { LinkablePersistentProgressLog, QueryableProgressLog } from "../handlers/events/delivery/log/ProgressLog";
-import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
-import { AddressChannels } from "../handlers/commands/editors/toclient/addressChannels";
+import {LinkablePersistentProgressLog, QueryableProgressLog} from "../handlers/events/delivery/log/ProgressLog";
+import {RemoteRepoRef} from "@atomist/automation-client/operations/common/RepoId";
+import {AddressChannels} from "../handlers/commands/editors/toclient/addressChannels";
 
 import * as slack from "@atomist/slack-messages/SlackMessages";
-import { InterpretedLog } from "../handlers/events/delivery/log/InterpretedLog";
+import {InterpretedLog} from "../handlers/events/delivery/log/InterpretedLog";
 
-export async function reportFailureInterpretation(interpretation: InterpretedLog,
+export async function reportFailureInterpretation(stepName: string,
+                                                  interpretation: InterpretedLog,
                                                   fullLog: LinkablePersistentProgressLog & QueryableProgressLog,
                                                   id: RemoteRepoRef,
                                                   ac: AddressChannels) {
     await ac({
-        text: `Failed deploy of ${slack.url(`${id.url}/tree/${id.sha}`, id.sha.substr(0, 6))}`,
+        text: `Failed ${stepName} of ${slack.url(`${id.url}/tree/${id.sha}`, id.sha.substr(0, 6))}`,
         attachments: [{
             title: interpretation.message || "Failure",
             title_link: fullLog.url,

--- a/src/util/reportFailureInterpretation.ts
+++ b/src/util/reportFailureInterpretation.ts
@@ -1,6 +1,6 @@
-import {LinkablePersistentProgressLog, QueryableProgressLog} from "../handlers/events/delivery/log/ProgressLog";
 import {RemoteRepoRef} from "@atomist/automation-client/operations/common/RepoId";
 import {AddressChannels} from "../handlers/commands/editors/toclient/addressChannels";
+import {LinkablePersistentProgressLog, QueryableProgressLog} from "../handlers/events/delivery/log/ProgressLog";
 
 import * as slack from "@atomist/slack-messages/SlackMessages";
 import {InterpretedLog} from "../handlers/events/delivery/log/InterpretedLog";
@@ -19,7 +19,7 @@ export async function reportFailureInterpretation(stepName: string,
             fallback: "relevant bits",
             text: interpretation.relevantPart,
             color: "#ff5050",
-            actions: retryButton? [retryButton] : []
+            actions: retryButton ? [retryButton] : [],
         }],
     });
     if (interpretation.includeFullLog) {

--- a/src/util/reportFailureInterpretation.ts
+++ b/src/util/reportFailureInterpretation.ts
@@ -1,0 +1,29 @@
+import { LinkablePersistentProgressLog, QueryableProgressLog } from "../handlers/events/delivery/log/ProgressLog";
+import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
+import { AddressChannels } from "../handlers/commands/editors/toclient/addressChannels";
+
+import * as slack from "@atomist/slack-messages/SlackMessages";
+import { InterpretedLog } from "../handlers/events/delivery/log/InterpretedLog";
+
+export async function reportFailureInterpretation(interpretation: InterpretedLog,
+                                                  fullLog: LinkablePersistentProgressLog & QueryableProgressLog,
+                                                  id: RemoteRepoRef,
+                                                  ac: AddressChannels) {
+    await ac({
+        text: `Failed deploy of ${slack.url(`${id.url}/tree/${id.sha}`, id.sha.substr(0, 6))}`,
+        attachments: [{
+            title: interpretation.message || "Failure",
+            title_link: fullLog.url,
+            fallback: "relevant bits",
+            text: interpretation.relevantPart,
+            color: "#ff5050",
+        }],
+    });
+    if (interpretation.includeFullLog) {
+        await ac({
+            content: fullLog.log,
+            fileType: "text",
+            fileName: `deploy-failure-${id.sha}.log`,
+        } as any);
+    }
+}


### PR DESCRIPTION
Deployers and local builders have the option to interpret the logs, deciding whether to display the full log as a snippet.

and for local deploys, add a Retry button.