### PR TITLE
More eventy: determine subsequent steps dynamically

### DIFF
--- a/src/handlers/events/delivery/FailDownstreamPhasesOnPhaseFailure.ts
+++ b/src/handlers/events/delivery/FailDownstreamPhasesOnPhaseFailure.ts
@@ -25,8 +25,7 @@ import Status = OnSuccessStatus.Status;
  * Respond to a failure status by failing downstream phases
  */
 @EventHandler("Fail downstream phases on a phase failure",
-    GraphQL.subscriptionFromFile("../../../../../graphql/subscription/OnFailureStatus.graphql",
-        __dirname))
+    GraphQL.subscriptionFromFile("graphql/subscription/OnFailureStatus.graphql"))
 export class FailDownstreamPhasesOnPhaseFailure implements HandleEvent<OnFailureStatus.Subscription> {
 
     @Secret(Secrets.OrgToken)

--- a/src/handlers/events/delivery/Phases.ts
+++ b/src/handlers/events/delivery/Phases.ts
@@ -4,15 +4,13 @@ import {
     TokenCredentials,
 } from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
 import {StatusState} from "../../../typings/types";
-import {createStatus, State, Status} from "../../commands/editors/toclient/ghub";
+import {createStatus, State} from "../../commands/editors/toclient/ghub";
 
 import {logger} from "@atomist/automation-client";
 import * as stringify from "json-stringify-safe";
 import { ApprovalGateParam } from "../gates/StatusApprovalGate";
-import {contextIsAfter, splitContext} from "./phases/gitHubContext";
+import {contextIsAfter, GitHubStatusContext, splitContext} from "./phases/gitHubContext";
 
-// convention: "sdm/atomist/#-env/#-phase" (the numbers are for ordering)
-export type GitHubStatusContext = string;
 
 export interface PlannedPhase {
     context: GitHubStatusContext;

--- a/src/handlers/events/delivery/build/BuildOnScanSuccessStatus.ts
+++ b/src/handlers/events/delivery/build/BuildOnScanSuccessStatus.ts
@@ -27,7 +27,7 @@ import { Builder } from "./Builder";
  * See a GitHub success status with context "scan" and trigger a build producing an artifact status
  */
 @EventHandler("Build on source scan success",
-    GraphQL.subscriptionFromFile("../../../../../../graphql/subscription/OnAnySuccessStatus.graphql",
+    GraphQL.subscriptionFromFile("../../../../../graphql/subscription/OnAnySuccessStatus.graphql",
         __dirname))
 export class BuildOnScanSuccessStatus implements StatusSuccessHandler {
 

--- a/src/handlers/events/delivery/build/BuildOnScanSuccessStatus.ts
+++ b/src/handlers/events/delivery/build/BuildOnScanSuccessStatus.ts
@@ -27,8 +27,7 @@ import { Builder } from "./Builder";
  * See a GitHub success status with context "scan" and trigger a build producing an artifact status
  */
 @EventHandler("Build on source scan success",
-    GraphQL.subscriptionFromFile("../../../../../graphql/subscription/OnAnySuccessStatus.graphql",
-        __dirname))
+    GraphQL.subscriptionFromFile("graphql/subscription/OnAnySuccessStatus.graphql"))
 export class BuildOnScanSuccessStatus implements StatusSuccessHandler {
 
     @Secret(Secrets.OrgToken)

--- a/src/handlers/events/delivery/build/SetStatusOnBuildComplete.ts
+++ b/src/handlers/events/delivery/build/SetStatusOnBuildComplete.ts
@@ -28,8 +28,7 @@ import { createStatus, State } from "../../../commands/editors/toclient/ghub";
  * Set build status on complete build
  */
 @EventHandler("Check endpoint",
-    GraphQL.subscriptionFromFile("../../../../../../graphql/subscription/OnBuildComplete.graphql",
-        __dirname))
+    GraphQL.subscriptionFromFile("graphql/subscription/OnBuildComplete.graphql",))
 export class SetStatusOnBuildComplete implements HandleEvent<OnBuildComplete.Subscription> {
 
     @Secret(Secrets.OrgToken)

--- a/src/handlers/events/delivery/deploy/DeployFromLocalOnFingerprint.ts
+++ b/src/handlers/events/delivery/deploy/DeployFromLocalOnFingerprint.ts
@@ -26,7 +26,7 @@ import {
     PlannedPhase,
     previousPhaseSucceeded,
 } from "../Phases";
-import { BuiltContext } from "../phases/core";
+import { BuiltContext } from "../phases/gitHubContext";
 import { deploy } from "./deploy";
 import { Deployer } from "./Deployer";
 import { TargetInfo } from "./Deployment";

--- a/src/handlers/events/delivery/deploy/DeployFromLocalOnFingerprint.ts
+++ b/src/handlers/events/delivery/deploy/DeployFromLocalOnFingerprint.ts
@@ -33,8 +33,7 @@ import { TargetInfo } from "./Deployment";
 
 // TODO could make more common with other deployer...
 @EventHandler("Deploy linked artifact",
-    GraphQL.subscriptionFromFile("../../../../../../graphql/subscription/OnDeployToProductionFingerprint.graphql",
-        __dirname))
+    GraphQL.subscriptionFromFile("graphql/subscription/OnDeployToProductionFingerprint.graphql",))
 export class DeployFromLocalOnFingerprint<T extends TargetInfo> implements HandleEvent<OnDeployToProductionFingerprint.Subscription> {
 
     @Secret(Secrets.OrgToken)

--- a/src/handlers/events/delivery/deploy/DeployFromLocalOnImageLinked.ts
+++ b/src/handlers/events/delivery/deploy/DeployFromLocalOnImageLinked.ts
@@ -40,8 +40,7 @@ import { TargetInfo } from "./Deployment";
  * Deploy a published artifact identified in an ImageLinked event.
  */
 @EventHandler("Deploy linked artifact",
-    GraphQL.subscriptionFromFile("../../../../../../graphql/subscription/OnImageLinked.graphql",
-        __dirname))
+    GraphQL.subscriptionFromFile("graphql/subscription/OnImageLinked.graphql",))
 export class DeployFromLocalOnImageLinked<T extends TargetInfo> implements HandleEvent<OnImageLinked.Subscription>, EventWithCommand {
 
     @Secret(Secrets.OrgToken)

--- a/src/handlers/events/delivery/deploy/DeployFromLocalOnImageLinked.ts
+++ b/src/handlers/events/delivery/deploy/DeployFromLocalOnImageLinked.ts
@@ -31,7 +31,7 @@ import {
     PlannedPhase,
     previousPhaseSucceeded,
 } from "../Phases";
-import { BuiltContext } from "../phases/core";
+import { BuiltContext } from "../phases/gitHubContext";
 import { deploy } from "./deploy";
 import { Deployer } from "./Deployer";
 import { TargetInfo } from "./Deployment";

--- a/src/handlers/events/delivery/deploy/OnDeployStatus.ts
+++ b/src/handlers/events/delivery/deploy/OnDeployStatus.ts
@@ -34,8 +34,8 @@ export type DeployListener = (id: GitHubRepoRef,
  * React to a deployment.
  */
 @EventHandler("React to a successful deployment",
-    GraphQL.subscriptionFromFile("../../../../../../graphql/subscription/OnSuccessStatus.graphql",
-        __dirname, {
+    GraphQL.subscriptionFromFile("graphql/subscription/OnSuccessStatus.graphql",
+        undefined, {
             context: CloudFoundryStagingDeploymentContext,
         }))
 export class OnDeployStatus implements HandleEvent<OnSuccessStatus.Subscription> {

--- a/src/handlers/events/delivery/deploy/deploy.ts
+++ b/src/handlers/events/delivery/deploy/deploy.ts
@@ -25,9 +25,10 @@ import {createStatus} from "../../../commands/editors/toclient/ghub";
 import {ArtifactStore} from "../ArtifactStore";
 import {createLinkableProgressLog} from "../log/NaiveLinkablePersistentProgressLog";
 import {ConsoleProgressLog, MultiProgressLog, QueryableProgressLog, SavingProgressLog} from "../log/ProgressLog";
-import {GitHubStatusContext, PlannedPhase} from "../Phases";
+import { PlannedPhase} from "../Phases";
 import {Deployer} from "./Deployer";
 import {TargetInfo} from "./Deployment";
+import {GitHubStatusContext} from "../phases/gitHubContext";
 
 export interface DeployParams<T extends TargetInfo> {
     deployPhase: PlannedPhase;

--- a/src/handlers/events/delivery/phase/OnSuperseded.ts
+++ b/src/handlers/events/delivery/phase/OnSuperseded.ts
@@ -25,8 +25,7 @@ export type SupersededListener = (id: GitHubRepoRef, s: OnSupersededStatus.Statu
  * Respond to a superseded push
  */
 @EventHandler("React to a superseded push",
-    GraphQL.subscriptionFromFile("../../../../../../graphql/subscription/OnSupersededStatus.graphql",
-        __dirname))
+    GraphQL.subscriptionFromFile("graphql/subscription/OnSupersededStatus.graphql"))
 export class OnSuperseded implements HandleEvent<OnSupersededStatus.Subscription> {
 
     @Secret(Secrets.OrgToken)

--- a/src/handlers/events/delivery/phase/SetSupersededStatus.ts
+++ b/src/handlers/events/delivery/phase/SetSupersededStatus.ts
@@ -33,8 +33,7 @@ export const SupersededContext = "superseded";
  * Set superseded status on previous commit on a push
  */
 @EventHandler("Scan code on master",
-    GraphQL.subscriptionFromFile("../../../../../../graphql/subscription/OnPushWithBefore.graphql",
-        __dirname))
+    GraphQL.subscriptionFromFile("graphql/subscription/OnPushWithBefore.graphql"))
 export class SetSupersededStatus implements HandleEvent<OnPushWithBefore.Subscription> {
 
     @Secret(Secrets.OrgToken)

--- a/src/handlers/events/delivery/phase/SetupPhasesOnPush.ts
+++ b/src/handlers/events/delivery/phase/SetupPhasesOnPush.ts
@@ -51,8 +51,7 @@ export const PushesToMaster: PushTest = p => p.branch === "master";
  * Scan code on a push. Results in setting up phases (e.g. for delivery).
  */
 @EventHandler("Scan code on master",
-    GraphQL.subscriptionFromFile("../../../../../../graphql/subscription/OnPushToAnyBranch.graphql",
-        __dirname))
+    GraphQL.subscriptionFromFile("graphql/subscription/OnPushToAnyBranch.graphql"))
 export class SetupPhasesOnPush implements HandleEvent<OnPushToAnyBranch.Subscription> {
 
     @Secret(Secrets.OrgToken)

--- a/src/handlers/events/delivery/phases/core.ts
+++ b/src/handlers/events/delivery/phases/core.ts
@@ -1,8 +1,0 @@
-
-export const BaseContext = "sdm/atomist/";
-export const IndependentOfEnvironment = "0-code/";
-export const StagingEnvironment = "1-staging/";
-export const ProductionEnvironment = "2-prod/";
-
-export const ScanContext = BaseContext + IndependentOfEnvironment + "1-scan";
-export const BuiltContext = BaseContext + IndependentOfEnvironment + "2-build";

--- a/src/handlers/events/delivery/phases/gitHubContext.ts
+++ b/src/handlers/events/delivery/phases/gitHubContext.ts
@@ -1,0 +1,57 @@
+import {GitHubStatusContext} from "../Phases";
+
+export const BaseContext = "sdm/atomist/";
+export const IndependentOfEnvironment = "0-code/";
+export const StagingEnvironment = "1-staging/";
+// should always be number dash name. The number may be a decimal
+export const ProductionEnvironment = "2-prod/";
+
+export const ScanContext = BaseContext + IndependentOfEnvironment + "1-scan";
+export const BuiltContext = BaseContext + IndependentOfEnvironment + "2-build";
+
+/**
+ * if this is a context we created, then we can interpret it.
+ * Otherwise returns undefined
+ * @param {string} context
+ * @returns {{base: string; env: string; stage: string}}
+ */
+export function splitContext(context: GitHubStatusContext) {
+    if (context.startsWith(BaseContext)) {
+        const numberAndName = /([0-9\.]+)-(.*)/;
+        const wholeContext = /^sdm\/atomist\/(.*)\/(.*)$/;
+
+        const matchWhole = context.match(wholeContext);
+        if (!matchWhole) {
+            return;
+        }
+
+        const phasePart = matchWhole[2];
+        const env = matchWhole[1];
+        const matchPhase = phasePart.match(numberAndName);
+        if (!matchPhase) {
+            return;
+        }
+        const name = matchPhase[2];
+        const order = +matchPhase[1];
+
+        return {base: BaseContext, env, name, order};
+    }
+}
+
+/*
+ * true if contextB is in the same series of phases as A,
+ * and A comes before B
+ */
+export function contextIsAfter(contextA: GitHubStatusContext, contextB: GitHubStatusContext): boolean {
+    if (belongToSameSeriesOfPhases(contextA, contextB)) {
+        const splitA = splitContext(contextA);
+        const splitB = splitContext(contextB);
+        return
+    }
+}
+
+function belongToSameSeriesOfPhases(contextA: GitHubStatusContext, contextB: GitHubStatusContext): boolean {
+    const splitA = splitContext(contextA);
+    const splitB = splitContext(contextB);
+    return splitA && splitB && splitA.env === splitB.env && splitA.base === splitB.base;
+}

--- a/src/handlers/events/delivery/phases/httpServicePhases.ts
+++ b/src/handlers/events/delivery/phases/httpServicePhases.ts
@@ -1,5 +1,5 @@
 import { Phases, PlannedPhase } from "../Phases";
-import { BaseContext, BuiltContext, ScanContext, StagingEnvironment } from "./core";
+import { BaseContext, BuiltContext, ScanContext, StagingEnvironment } from "./gitHubContext";
 
 export const CloudFoundryStagingDeploymentContext = BaseContext + StagingEnvironment + "3-PCF deploy";
 export const StagingEndpointContext = BaseContext + StagingEnvironment + "4-endpoint";

--- a/src/handlers/events/delivery/phases/libraryPhases.ts
+++ b/src/handlers/events/delivery/phases/libraryPhases.ts
@@ -1,5 +1,5 @@
 import { Phases } from "../Phases";
-import { BuiltContext, ScanContext } from "./core";
+import { BuiltContext, ScanContext } from "./gitHubContext";
 
 export const LibraryPhases = new Phases([
     ScanContext,

--- a/src/handlers/events/delivery/phases/productionDeployPhases.ts
+++ b/src/handlers/events/delivery/phases/productionDeployPhases.ts
@@ -1,6 +1,6 @@
 
 import { Phases } from "../Phases";
-import { BaseContext, ProductionEnvironment } from "./core";
+import { BaseContext, ProductionEnvironment } from "./gitHubContext";
 
 // TODO get rid of hard coding of number
 

--- a/src/handlers/events/delivery/review/WithCodeOnPendingScanStatus.ts
+++ b/src/handlers/events/delivery/review/WithCodeOnPendingScanStatus.ts
@@ -42,7 +42,7 @@ import {GitProject} from "@atomist/automation-client/project/git/GitProject";
 import {OnAnyPendingStatus, StatusState} from "../../../../typings/types";
 import {AddressChannels, addressChannelsFor} from "../../../commands/editors/toclient/addressChannels";
 import {createStatus} from "../../../commands/editors/toclient/ghub";
-import {ScanContext} from "../phases/core";
+import {ScanContext} from "../phases/gitHubContext";
 import {ContextToPlannedPhase} from "../phases/httpServicePhases";
 import {ApprovalGateParam} from "../../gates/StatusApprovalGate";
 import {MessagingReviewRouter} from "@atomist/spring-automation/commands/messagingReviewRouter";

--- a/src/handlers/events/delivery/review/WithCodeOnPendingScanStatus.ts
+++ b/src/handlers/events/delivery/review/WithCodeOnPendingScanStatus.ts
@@ -67,8 +67,7 @@ export type CodeReaction = (p: GitProject,
  * Result is setting GitHub status with context = "scan"
  */
 @EventHandler("Scan code",
-    GraphQL.subscriptionFromFile("../../../../../../graphql/subscription/OnAnyPendingStatus.graphql",
-        __dirname))
+    GraphQL.subscriptionFromFile("graphql/subscription/OnAnyPendingStatus.graphql",))
 export class WithCodeOnPendingScanStatus implements HandleEvent<OnAnyPendingStatus.Subscription> {
 
     @Secret(Secrets.OrgToken)

--- a/src/handlers/events/delivery/verify/OnVerifiedStatus.ts
+++ b/src/handlers/events/delivery/verify/OnVerifiedStatus.ts
@@ -39,8 +39,8 @@ export type VerifiedDeploymentListener = (id: GitHubRepoRef, s: StatusInfo,
  * Deploy a published artifact identified in a GitHub "artifact" status.
  */
 @EventHandler("Act on verified project",
-    GraphQL.subscriptionFromFile("../../../../../../graphql/subscription/OnSuccessStatus.graphql",
-        __dirname, {
+    GraphQL.subscriptionFromFile("graphql/subscription/OnSuccessStatus.graphql",
+        undefined, {
             context: StagingVerifiedContext,
         }))
 export class OnVerifiedStatus implements HandleEvent<OnSuccessStatus.Subscription> {

--- a/src/handlers/events/delivery/verify/VerifyOnEndpointStatus.ts
+++ b/src/handlers/events/delivery/verify/VerifyOnEndpointStatus.ts
@@ -41,8 +41,8 @@ export type EndpointVerifier = (url: string,
  * Deploy a published artifact identified in a GitHub "artifact" status.
  */
 @EventHandler("Check endpoint",
-    GraphQL.subscriptionFromFile("../../../../../../graphql/subscription/OnSuccessStatus.graphql",
-        __dirname, {
+    GraphQL.subscriptionFromFile("graphql/subscription/OnSuccessStatus.graphql", undefined,
+        {
             context: StagingEndpointContext,
         }))
 export class VerifyOnEndpointStatus implements HandleEvent<OnSuccessStatus.Subscription> {

--- a/src/handlers/events/gates/StatusApprovalGate.ts
+++ b/src/handlers/events/gates/StatusApprovalGate.ts
@@ -36,8 +36,7 @@ export const ApprovalGateParam = "?atomist:approve=true";
  * Update a status.
  */
 @EventHandler("Approval gate",
-    GraphQL.subscriptionFromFile("../../../../graphql/subscription/OnAnySuccessStatus.graphql",
-        __dirname))
+    GraphQL.subscriptionFromFile("graphql/subscription/OnAnySuccessStatus.graphql"))
 export class StatusApprovalGate implements HandleEvent<OnAnySuccessStatus.Subscription> {
 
     @Secret(Secrets.OrgToken)

--- a/src/handlers/events/gates/StatusApprovalGate.ts
+++ b/src/handlers/events/gates/StatusApprovalGate.ts
@@ -36,7 +36,7 @@ export const ApprovalGateParam = "?atomist:approve=true";
  * Update a status.
  */
 @EventHandler("Approval gate",
-    GraphQL.subscriptionFromFile("../../../../../graphql/subscription/OnAnySuccessStatus.graphql",
+    GraphQL.subscriptionFromFile("../../../../graphql/subscription/OnAnySuccessStatus.graphql",
         __dirname))
 export class StatusApprovalGate implements HandleEvent<OnAnySuccessStatus.Subscription> {
 

--- a/src/sdm/AbstractSoftwareDeliveryMachine.ts
+++ b/src/sdm/AbstractSoftwareDeliveryMachine.ts
@@ -10,7 +10,7 @@ import { OnSuperseded, SupersededListener } from "../handlers/events/delivery/ph
 import { SetSupersededStatus } from "../handlers/events/delivery/phase/SetSupersededStatus";
 import { SetupPhasesOnPush } from "../handlers/events/delivery/phase/SetupPhasesOnPush";
 import { Phases } from "../handlers/events/delivery/Phases";
-import { BuiltContext } from "../handlers/events/delivery/phases/core";
+import { BuiltContext } from "../handlers/events/delivery/phases/gitHubContext";
 import {
     CodeReaction,
     WithCodeOnPendingScanStatus,

--- a/src/software-delivery-machine/SpringPCFSoftwareDeliveryMachine.ts
+++ b/src/software-delivery-machine/SpringPCFSoftwareDeliveryMachine.ts
@@ -3,7 +3,7 @@ import { Maker } from "@atomist/automation-client/util/constructionUtils";
 import { springBootTagger } from "@atomist/spring-automation/commands/tag/springTagger";
 import { SetupPhasesOnPush } from "../handlers/events/delivery/phase/SetupPhasesOnPush";
 import { Phases } from "../handlers/events/delivery/Phases";
-import { ScanContext } from "../handlers/events/delivery/phases/core";
+import { ScanContext } from "../handlers/events/delivery/phases/gitHubContext";
 import { HttpServicePhases } from "../handlers/events/delivery/phases/httpServicePhases";
 import { LibraryPhases } from "../handlers/events/delivery/phases/libraryPhases";
 import { checkstyleReviewer } from "../handlers/events/delivery/review/checkstyleReviewer";

--- a/src/software-delivery-machine/blueprint/build/LocalMavenBuildOnScanSuccessStatus.ts
+++ b/src/software-delivery-machine/blueprint/build/LocalMavenBuildOnScanSuccessStatus.ts
@@ -1,7 +1,7 @@
 import { BuildOnScanSuccessStatus } from "../../../handlers/events/delivery/build/BuildOnScanSuccessStatus";
 import { MavenBuilder } from "../../../handlers/events/delivery/build/local/maven/MavenBuilder";
 import { createLinkableProgressLog } from "../../../handlers/events/delivery/log/NaiveLinkablePersistentProgressLog";
-import { BuiltContext } from "../../../handlers/events/delivery/phases/core";
+import { BuiltContext } from "../../../handlers/events/delivery/phases/gitHubContext";
 import { HttpServicePhases } from "../../../handlers/events/delivery/phases/httpServicePhases";
 import { artifactStore } from "../artifactStore";
 

--- a/src/software-delivery-machine/blueprint/deploy/deployToProd.ts
+++ b/src/software-delivery-machine/blueprint/deploy/deployToProd.ts
@@ -14,7 +14,7 @@ import { addressSlackUsers } from "@atomist/automation-client/spi/message/Messag
 import * as slack from "@atomist/slack-messages/SlackMessages";
 import { sendFingerprint } from "../../../handlers/commands/editors/toclient/fingerprints";
 import { listStatuses, Status } from "../../../handlers/commands/editors/toclient/ghub";
-import { BuiltContext } from "../../../handlers/events/delivery/phases/core";
+import { BuiltContext } from "../../../handlers/events/delivery/phases/gitHubContext";
 import { ProductionDeployPhases } from "../../../handlers/events/delivery/phases/productionDeployPhases";
 
 @CommandHandler("Promote to production", "promote to production")

--- a/test/handlers/events/delivery/PhasesTest.ts
+++ b/test/handlers/events/delivery/PhasesTest.ts
@@ -1,7 +1,7 @@
 import "mocha";
 import * as assert from "power-assert";
 import {parseContext} from "../../../../src/handlers/events/delivery/Phases";
-import {ScanContext} from "../../../../src/handlers/events/delivery/phases/core";
+import {ScanContext} from "../../../../src/handlers/events/delivery/phases/gitHubContext";
 
 describe("Phase handling", () => {
    it("parses my contexts", () => {

--- a/test/handlers/events/delivery/PhasesTest.ts
+++ b/test/handlers/events/delivery/PhasesTest.ts
@@ -1,13 +1,25 @@
 import "mocha";
 import * as assert from "power-assert";
-import {parseContext} from "../../../../src/handlers/events/delivery/Phases";
-import {ScanContext} from "../../../../src/handlers/events/delivery/phases/gitHubContext";
+import {BaseContext, BuiltContext, contextIsAfter, ScanContext, splitContext} from "../../../../src/handlers/events/delivery/phases/gitHubContext";
+import {CloudFoundryStagingDeploymentContext, StagingEndpointContext} from "../../../../src/handlers/events/delivery/phases/httpServicePhases";
 
 describe("Phase handling", () => {
    it("parses my contexts", () => {
-       const result = parseContext(ScanContext);
+       const result = splitContext(ScanContext);
        assert.equal(result.name, "scan");
-       assert.equal(result.context, ScanContext);
+       assert.equal(result.base, BaseContext);
+       assert.equal(result.env, "code");
+       assert.equal(result.envOrder, 0);
+       assert.equal(result.name, "scan");
+       assert.equal(result.phaseOrder, 1);
    });
+
+   it("says endpoint is after deploy", () => {
+       assert(contextIsAfter(CloudFoundryStagingDeploymentContext, StagingEndpointContext))
+   })
+
+   it("says deploy is after build", () => {
+       assert(contextIsAfter(BuiltContext, CloudFoundryStagingDeploymentContext))
+   })
 
 });


### PR DESCRIPTION
This branch has some useful fixes on it, like making tests run at all

The meaningful change is to gameOver: it parses the pending statuses to find the ones to update instead of using the hard-coded list.
I wanted to show the idea of, working from the plan as it is laid out on the commit (in GH statuses), instead of from the hard-coded list of phases.

The idea is, the plan could be modified. Scan could decide to add an extra verification step, or something. The goal is to decouple (to some degree) the decision of what to do, from the doing of it. It's more event-y.

There are other places still working from the hard-coded list but this is a start.