### PR TITLE
Begin work to switch to GitHub releases for storing artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,45 @@
 
 GitHub Software Delivery Machine.
 
+## Concepts
+This repository shows how Atomist can automate important tasks,
+and improve your delivery flow. Specifically:
+
+- How Atomist command handlers and event handlers can be used to create services
+the right way every time, and help keep them up to date 
+- How Atomist event handlers can drive and improve a custom delivery experience, from commit through 
+to deployment and testing
+
+This repository is intended for
+use both as a starting point for your own Atomist implementation, and as a reference.
+
+Atomist is not tied to GitHub, but this repository focuses on using Atomist with GitHub.com or
+GitHub Enterprise.
+
+## Key events
+The heart of Atomist is its event handling. As your code flows from commit
+through to deployment and beyond, Atomist receives events, correlates the incoming data
+with its previous knowledge, and can invoke your event handlers.
+
+Event handlers subscribe to events using GraphQL subscriptions. This repository
+includes event handlers that subscribe to some of the most important events in a typical
+delivery flow. This enables dynamic and sophisticated delivery processes that are consistent across
+multiple projects.
+
+The key events handled in this repository are:
+
+- _On repo creation_. When a new repository has been created, we often want to perform
+additional actions, such as provisioning an issue tracker. We provide a hook for this
+and also demonstrate how to add GitHub topics based on initial repo content.  
+- _On push to a repo._ Code push
+- _On build result._ 
+- _On image link._
+- _On successful deployment_, as shown by a GitHub status.
+- _On validation of a deployed endpoint_, as shown by a GitHub status.
+
+Promotion
+
+
 ## "Blueprint" interfaces and classes
 
 ## Environment variables

--- a/README.md
+++ b/README.md
@@ -17,33 +17,45 @@ use both as a starting point for your own Atomist implementation, and as a refer
 Atomist is not tied to GitHub, but this repository focuses on using Atomist with GitHub.com or
 GitHub Enterprise.
 
-## Key events
+## Events
 The heart of Atomist is its event handling. As your code flows from commit
 through to deployment and beyond, Atomist receives events, correlates the incoming data
-with its previous knowledge, and can invoke your event handlers.
+with its previous knowledge, and invokes your event handlers with rich context. This enables you to perform tasks such as:
+
+- Scanning code for security or quality issues on every push
+- Driving deployments and promotion between environments
+
+It also enables Atomist to provide you with visibility throughout the commit to deployment flow, in Slack or through the Atomist web dashboard.
+
 
 Event handlers subscribe to events using GraphQL subscriptions. This repository
 includes event handlers that subscribe to some of the most important events in a typical
 delivery flow. This enables dynamic and sophisticated delivery processes that are consistent across
 multiple projects.
 
+## Key Events
+
 The key events handled in this repository are:
 
 - _On repo creation_. When a new repository has been created, we often want to perform
 additional actions, such as provisioning an issue tracker. We provide a hook for this
 and also demonstrate how to add GitHub topics based on initial repo content.  
-- _On push to a repo._ Code push
-- _On build result._ 
-- _On image link._
+- _On push to a repo._ This is often a trigger for code review or other actions based on code.
+- _On image link._ A trigger for deployment.
 - _On successful deployment_, as shown by a GitHub status.
 - _On validation of a deployed endpoint_, as shown by a GitHub status.
 
-Promotion
+## GitHub Statuses
+We use the following GitHub statuses to drive our flow and show the stages:
+
+- tbd
+
+This is configurable
 
 
 ## "Blueprint" interfaces and classes
 
-## Environment variables
+## Environment Variables
 For the optional Checkstyle integration to work, set up a Checkstyle environment variable as follows:
 
 ```

--- a/src/handlers/commands/editors/toclient/ghub.ts
+++ b/src/handlers/commands/editors/toclient/ghub.ts
@@ -16,7 +16,7 @@ export interface Status {
 export function createStatus(token: string, rr: GitHubRepoRef, status: Status): AxiosPromise {
     const config = authHeaders(token);
     const url = `${rr.apiBase}/repos/${rr.owner}/${rr.repo}/statuses/${rr.sha}`;
-    logger.info("Updating github status: $s to %j", url, status);
+    logger.info("Updating github status: %s to %j", url, status);
     return axios.post(url, status, config)
         .catch(err =>
             Promise.reject(new Error(`Error hitting ${url} to set status ${JSON.stringify(status)}: ${err.message}`)),

--- a/src/handlers/commands/editors/toclient/ghub.ts
+++ b/src/handlers/commands/editors/toclient/ghub.ts
@@ -1,7 +1,7 @@
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import axios, { AxiosPromise, AxiosRequestConfig } from "axios";
 import { logger } from "@atomist/automation-client";
-import ReadStream = NodeJS.ReadStream;
+import { ReadStream } from "fs";
 
 export type State = "error" | "failure" | "pending" | "success";
 
@@ -47,9 +47,9 @@ export function createTag(token: string, rr: GitHubRepoRef, tag: Tag): AxiosProm
     const config = authHeaders(token);
     const url = `${rr.apiBase}/repos/${rr.owner}/${rr.repo}/git/tags`;
     logger.info("Updating github tag: %s to %j", url, tag);
-    return axios.post(url, status, config)
+    return axios.post(url, tag, config)
         .catch(err =>
-            Promise.reject(new Error(`Error hitting ${url} to set tag ${JSON.stringify(status)}: ${err.message}`)),
+            Promise.reject(new Error(`Error hitting ${url} to set tag ${JSON.stringify(tag)}: ${err.message}`)),
         );
 }
 
@@ -78,7 +78,7 @@ export function uploadReleaseAsset(token: string, rr: GitHubRepoRef, releaseId: 
     logger.info("Updating github release asset: %s named %s to release %s", url, name, releaseId);
     return axios.post(url, readSteam, config)
         .catch(err =>
-            Promise.reject(new Error(`Error hitting ${url} to set status ${JSON.stringify(status)}: ${err.message}`)),
+            Promise.reject(new Error(`Error hitting ${url} to set release ${releaseId}: ${err.message}`)),
         );
 }
 

--- a/src/handlers/commands/editors/toclient/ghub.ts
+++ b/src/handlers/commands/editors/toclient/ghub.ts
@@ -91,7 +91,8 @@ export async function uploadReleaseAsset(token: string,
     const size = (await promisify(fs.stat)(localFile)).size;
     const config = streamHeaders(token, size);
     const url = `${rr.apiBase}/repos/${rr.owner}/${rr.repo}/releases/${releaseId}/assets?name=${name}`;
-    logger.info("Publishing github release asset: %s named %s to release %s", url, name, releaseId);
+    logger.info("Publishing github release asset: %s named %s to release %s with config %j",
+        url, name, releaseId, config);
     return axios.post(url, readStream, config)
         .then(r => r.data)
         .catch(err =>

--- a/src/handlers/events/delivery/ArtifactStore.ts
+++ b/src/handlers/events/delivery/ArtifactStore.ts
@@ -1,17 +1,7 @@
-
-import * as Stream from "stream";
 import { AppInfo } from "./deploy/Deployment";
 import { ProjectOperationCredentials } from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
 
 export interface ArtifactStore {
-
-    /**
-     * Returns the URL of a StoredArtifact
-     * @param {string} appInfo
-     * @param {ReadableStream} what
-     * @return {Promise<String>}
-     */
-    store(appInfo: AppInfo, what: Stream, creds: ProjectOperationCredentials): Promise<string>;
 
     /**
      * Store an artifact we have locally at the given absolute path

--- a/src/handlers/events/delivery/ArtifactStore.ts
+++ b/src/handlers/events/delivery/ArtifactStore.ts
@@ -1,6 +1,7 @@
 
 import * as Stream from "stream";
 import { AppInfo } from "./deploy/Deployment";
+import { ProjectOperationCredentials } from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
 
 export interface ArtifactStore {
 
@@ -10,7 +11,7 @@ export interface ArtifactStore {
      * @param {ReadableStream} what
      * @return {Promise<String>}
      */
-    store(appInfo: AppInfo, what: Stream): Promise<string>;
+    store(appInfo: AppInfo, what: Stream, creds: ProjectOperationCredentials): Promise<string>;
 
     /**
      * Store an artifact we have locally at the given absolute path
@@ -19,11 +20,9 @@ export interface ArtifactStore {
      * @return {Promise<string>} promise of the url at which the
      * StoredArtifact can be retrieved
      */
-    storeFile(appInfo: AppInfo, localFile: string): Promise<string>;
+    storeFile(appInfo: AppInfo, localFile: string, creds: ProjectOperationCredentials): Promise<string>;
 
-    retrieve(url: string): Promise<StoredArtifact>;
-
-    checkout(url: string): Promise<DeployableArtifact>;
+    checkout(url: string, creds: ProjectOperationCredentials): Promise<DeployableArtifact>;
 }
 
 export interface StoredArtifact {

--- a/src/handlers/events/delivery/artifact/github/GitHubReleaseArtifactStore.ts
+++ b/src/handlers/events/delivery/artifact/github/GitHubReleaseArtifactStore.ts
@@ -1,0 +1,50 @@
+import { ArtifactStore, DeployableArtifact } from "../../ArtifactStore";
+import { AppInfo } from "../../deploy/Deployment";
+import { Stream } from "stream";
+import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
+import { createRelease, createTag, Release, Tag, uploadReleaseAsset } from "../../../../commands/editors/toclient/ghub";
+import * as fs from "fs";
+import {
+    ProjectOperationCredentials,
+    TokenCredentials
+} from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
+
+export class GitHubReleaseArtifactStore implements ArtifactStore {
+
+    public store(appInfo: AppInfo, what: Stream): Promise<string> {
+        throw new Error("Not yet implemented");
+    }
+
+    public async storeFile(appInfo: AppInfo, localFile: string, creds: ProjectOperationCredentials): Promise<string> {
+        const token = (creds as TokenCredentials).token;
+
+        const tagName = appInfo.version + new Date().getMilliseconds();
+        const tag: Tag = {
+            tag: tagName,
+            message: appInfo.version + " for release",
+            object: appInfo.id.sha,
+            type: "commit",
+            tagger: {
+                name: "Atomist",
+                email: "info@atomist.com",
+                date: new Date().toISOString(),
+            },
+        };
+        const grr = appInfo.id as GitHubRepoRef;
+        await createTag(token, grr, tag);
+        const release: Release = {
+            name: appInfo.version,
+            tag_name: tag.tag,
+        };
+        await createRelease(token, grr, release);
+        const lastSlash = localFile.lastIndexOf("/");
+        const filename = localFile.substr(lastSlash + 1);
+        const asset = await uploadReleaseAsset(token, grr, release.name, filename,
+            localFile);
+        return asset.url;
+    }
+
+    public checkout(url: string, creds: ProjectOperationCredentials): Promise<DeployableArtifact> {
+        throw new Error("Not yet implemented");
+    }
+}

--- a/src/handlers/events/delivery/artifact/github/GitHubReleaseArtifactStore.ts
+++ b/src/handlers/events/delivery/artifact/github/GitHubReleaseArtifactStore.ts
@@ -1,19 +1,13 @@
 import { ArtifactStore, DeployableArtifact } from "../../ArtifactStore";
 import { AppInfo } from "../../deploy/Deployment";
-import { Stream } from "stream";
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import { createRelease, createTag, Release, Tag, uploadReleaseAsset } from "../../../../commands/editors/toclient/ghub";
-import * as fs from "fs";
 import {
     ProjectOperationCredentials,
     TokenCredentials
 } from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
 
 export class GitHubReleaseArtifactStore implements ArtifactStore {
-
-    public store(appInfo: AppInfo, what: Stream): Promise<string> {
-        throw new Error("Not yet implemented");
-    }
 
     public async storeFile(appInfo: AppInfo, localFile: string, creds: ProjectOperationCredentials): Promise<string> {
         const token = (creds as TokenCredentials).token;

--- a/src/handlers/events/delivery/artifact/local/LocalArtifactStore.ts
+++ b/src/handlers/events/delivery/artifact/local/LocalArtifactStore.ts
@@ -26,7 +26,7 @@ export class LocalArtifactStore implements ArtifactStore {
         return Promise.resolve(entry.url);
     }
 
-    public retrieve(url: string): Promise<StoredArtifact> {
+    protected retrieve(url: string): Promise<StoredArtifact> {
         return Promise.resolve(this.entries.find(e => e.url === url));
     }
 

--- a/src/handlers/events/delivery/artifact/local/LocalArtifactStore.ts
+++ b/src/handlers/events/delivery/artifact/local/LocalArtifactStore.ts
@@ -10,11 +10,6 @@ export class LocalArtifactStore implements ArtifactStore {
 
     private entries: Array<StoredArtifact & { url: string }> = [];
 
-    public store(appInfo: AppInfo, what: Stream): Promise<string> {
-        console.log("Storing " + JSON.stringify(appInfo));
-        throw new Error("not yet supported");
-    }
-
     public storeFile(appInfo: AppInfo, what: string): Promise<string> {
         console.log("Storing " + JSON.stringify(appInfo));
         const entry = {

--- a/src/handlers/events/delivery/build/local/LocalBuilder.ts
+++ b/src/handlers/events/delivery/build/local/LocalBuilder.ts
@@ -10,16 +10,12 @@ import { AddressChannels } from "../../../../commands/editors/toclient/addressCh
 import { postLinkImageWebhook } from "../../../link/ImageLink";
 import { ArtifactStore } from "../../ArtifactStore";
 import { AppInfo } from "../../deploy/Deployment";
-import EventEmitter = NodeJS.EventEmitter;
-import { InterpretedLog, LogInterpretation, LogInterpreter } from "../../log/InterpretedLog";
-import {
-    LinkableLogFactory, LinkablePersistentProgressLog, ProgressLog,
-    QueryableProgressLog,
-} from "../../log/ProgressLog";
+import { InterpretedLog, LogInterpreter } from "../../log/InterpretedLog";
+import { LinkableLogFactory, LinkablePersistentProgressLog, QueryableProgressLog, } from "../../log/ProgressLog";
 import { Builder } from "../Builder";
 import { createRelease, createTag, Release, Tag, uploadReleaseAsset } from "../../../../commands/editors/toclient/ghub";
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
-import * as fs from "fs";
+import EventEmitter = NodeJS.EventEmitter;
 
 export interface LocalBuildInProgress {
 
@@ -156,7 +152,8 @@ async function linkArtifact(token: string, rb: LocalBuildInProgress, team: strin
     await createRelease(token, grr, release);
     const lastSlash = rb.deploymentUnitFile.lastIndexOf("/");
     const filename = rb.deploymentUnitFile.substr(lastSlash + 1);
-    await uploadReleaseAsset(token, grr, release.name, filename, fs.createReadStream(rb.deploymentUnitFile));
-    return artifactStore.storeFile(rb.appInfo, rb.deploymentUnitFile)
+    const asset = await uploadReleaseAsset(token, grr, release.name, filename, rb.deploymentUnitFile);
+    return artifactStore.storeFile(rb.appInfo, rb.deploymentUnitFile, {token})
         .then(imageUrl => postLinkImageWebhook(rb.repoRef.owner, rb.repoRef.repo, rb.repoRef.sha, imageUrl, team));
+    //return postLinkImageWebhook(rb.repoRef.owner, rb.repoRef.repo, rb.repoRef.sha, asset.url, team);
 }

--- a/src/handlers/events/delivery/deploy/Deployer.ts
+++ b/src/handlers/events/delivery/deploy/Deployer.ts
@@ -3,6 +3,7 @@ import { DeployableArtifact } from "../ArtifactStore";
 import { LogInterpretation } from "../log/InterpretedLog";
 import { QueryableProgressLog } from "../log/ProgressLog";
 import { Deployment, TargetInfo } from "./Deployment";
+import { ProjectOperationCredentials } from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
 
 export interface Deployer<T extends TargetInfo = TargetInfo> extends LogInterpretation {
 
@@ -13,6 +14,9 @@ export interface Deployer<T extends TargetInfo = TargetInfo> extends LogInterpre
      */
     undeploy?(id: RemoteRepoRef): Promise<any>;
 
-    deploy(ai: DeployableArtifact, ti: T, log: QueryableProgressLog): Promise<Deployment>;
+    deploy(da: DeployableArtifact,
+           ti: T,
+           log: QueryableProgressLog,
+           creds: ProjectOperationCredentials): Promise<Deployment>;
 
 }

--- a/src/handlers/events/delivery/deploy/deploy.ts
+++ b/src/handlers/events/delivery/deploy/deploy.ts
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-import {HandlerResult, logger, success} from "@atomist/automation-client";
-import {GitHubRepoRef} from "@atomist/automation-client/operations/common/GitHubRepoRef";
-import {RemoteRepoRef} from "@atomist/automation-client/operations/common/RepoId";
-import {Action} from "@atomist/slack-messages";
-import {StatusState} from "../../../../typings/types";
-import {reportFailureInterpretation} from "../../../../util/reportFailureInterpretation";
-import {AddressChannels} from "../../../commands/editors/toclient/addressChannels";
-import {createStatus} from "../../../commands/editors/toclient/ghub";
-import {ArtifactStore} from "../ArtifactStore";
-import {createLinkableProgressLog} from "../log/NaiveLinkablePersistentProgressLog";
-import {ConsoleProgressLog, MultiProgressLog, QueryableProgressLog, SavingProgressLog} from "../log/ProgressLog";
-import { PlannedPhase} from "../Phases";
-import {Deployer} from "./Deployer";
-import {TargetInfo} from "./Deployment";
-import {GitHubStatusContext} from "../phases/gitHubContext";
+import { HandlerResult, logger, success } from "@atomist/automation-client";
+import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
+import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
+import { Action } from "@atomist/slack-messages";
+import { StatusState } from "../../../../typings/types";
+import { reportFailureInterpretation } from "../../../../util/reportFailureInterpretation";
+import { AddressChannels } from "../../../commands/editors/toclient/addressChannels";
+import { createStatus } from "../../../commands/editors/toclient/ghub";
+import { ArtifactStore } from "../ArtifactStore";
+import { createLinkableProgressLog } from "../log/NaiveLinkablePersistentProgressLog";
+import { ConsoleProgressLog, MultiProgressLog, QueryableProgressLog, SavingProgressLog } from "../log/ProgressLog";
+import { PlannedPhase } from "../Phases";
+import { Deployer } from "./Deployer";
+import { TargetInfo } from "./Deployment";
+import { GitHubStatusContext } from "../phases/gitHubContext";
 
 export interface DeployParams<T extends TargetInfo> {
     deployPhase: PlannedPhase;
@@ -83,12 +83,17 @@ export async function deploy<T extends TargetInfo>(paramsOrDeployPhase: PlannedP
         const savingLog = new SavingProgressLog();
         const progressLog = new MultiProgressLog(ConsoleProgressLog, savingLog, linkableLog) as any as QueryableProgressLog;
 
-        const artifactCheckout = await artifactStore.checkout(targetUrl).catch(err => {
-            console.log("Writing to progress log");
-            progressLog.write("Error checking out artifact: " + err.message);
-            return progressLog.close().then(() => Promise.reject(err));
-        });
-        const deployment = await deployer.deploy(artifactCheckout, targeter(id), progressLog);
+        const artifactCheckout = await artifactStore.checkout(targetUrl, {token: githubToken})
+            .catch(err => {
+                console.log("Writing to progress log");
+                progressLog.write("Error checking out artifact: " + err.message);
+                return progressLog.close().then(() => Promise.reject(err));
+            });
+        const deployment = await deployer.deploy(
+            artifactCheckout,
+            targeter(id),
+            progressLog,
+            {token: githubToken});
 
         await progressLog.close();
         await setDeployStatus(githubToken, id,

--- a/src/handlers/events/delivery/deploy/pcf/CloudFoundryTarget.ts
+++ b/src/handlers/events/delivery/deploy/pcf/CloudFoundryTarget.ts
@@ -1,6 +1,12 @@
 
 import { TargetInfo } from "../Deployment";
 
+/**
+ * Path to Cloud Foundry manifest within deployable projects
+ * @type {string}
+ */
+export const ManifestPath = "manifest.yml";
+
 export interface CloudFoundryInfo extends TargetInfo {
 
     api: string;

--- a/src/sdm/AbstractSoftwareDeliveryMachine.ts
+++ b/src/sdm/AbstractSoftwareDeliveryMachine.ts
@@ -38,6 +38,8 @@ export abstract class AbstractSoftwareDeliveryMachine implements SoftwareDeliver
 
     public editors: Array<Maker<HandleCommand>> = [];
 
+    public supportingCommands: Array<Maker<HandleCommand>> = [];
+
     private newRepoWithCodeActions: NewRepoWithCodeAction[] = [];
 
     private projectReviewers: ProjectReviewer[] = [];
@@ -118,11 +120,6 @@ export abstract class AbstractSoftwareDeliveryMachine implements SoftwareDeliver
     public onBuildComplete: Maker<SetStatusOnBuildComplete> =
         () => new SetStatusOnBuildComplete(BuiltContext)
 
-    /**
-     * Miscellaneous supporting commands
-     */
-    public abstract supportingCommands: Array<Maker<HandleCommand>>;
-
     get eventHandlers(): Array<Maker<HandleEvent<any>>> {
         return (this.phaseCleanup as Array<Maker<HandleEvent<any>>>)
             .concat([
@@ -163,6 +160,11 @@ export abstract class AbstractSoftwareDeliveryMachine implements SoftwareDeliver
 
     public addEditors(...e: Array<Maker<HandleCommand>>): this {
         this.editors = this.editors.concat(e);
+        return this;
+    }
+
+    public addSupportingCommands(...e: Array<Maker<HandleCommand>>): this {
+        this.supportingCommands = this.supportingCommands.concat(e);
         return this;
     }
 

--- a/src/software-delivery-machine/SpringPCFSoftwareDeliveryMachine.ts
+++ b/src/software-delivery-machine/SpringPCFSoftwareDeliveryMachine.ts
@@ -1,4 +1,4 @@
-import { HandleCommand, HandleEvent, logger } from "@atomist/automation-client";
+import { HandleEvent, logger } from "@atomist/automation-client";
 import { Maker } from "@atomist/automation-client/util/constructionUtils";
 import { springBootTagger } from "@atomist/spring-automation/commands/tag/springTagger";
 import { SetupPhasesOnPush } from "../handlers/events/delivery/phase/SetupPhasesOnPush";
@@ -63,11 +63,6 @@ export class SpringPCFSoftwareDeliveryMachine extends AbstractSoftwareDeliveryMa
         deploy: CloudFoundryProductionDeployOnFingerprint,
     };
 
-    public supportingCommands: Array<Maker<HandleCommand>> = [
-        () => addCloudFoundryManifest,
-        DescribeStagingAndProd,
-    ];
-
     get possiblePhases(): Phases[] {
         return [HttpServicePhases, LibraryPhases];
     }
@@ -102,6 +97,10 @@ export class SpringPCFSoftwareDeliveryMachine extends AbstractSoftwareDeliveryMa
                 id => {
                     logger.info("Will undeploy application %j", id);
                     return LocalMavenDeployer.deployer.undeploy(id);
-                });
+                })
+            .addSupportingCommands(
+                () => addCloudFoundryManifest,
+                DescribeStagingAndProd,
+            );
     }
 }

--- a/src/software-delivery-machine/SpringPCFSoftwareDeliveryMachine.ts
+++ b/src/software-delivery-machine/SpringPCFSoftwareDeliveryMachine.ts
@@ -16,7 +16,10 @@ import { AbstractSoftwareDeliveryMachine } from "../sdm/AbstractSoftwareDelivery
 import { PromotedEnvironment } from "../sdm/ReferenceDeliveryBlueprint";
 import { OnImageLinked } from "../typings/types";
 import { LocalMavenBuildOnSucessStatus } from "./blueprint/build/LocalMavenBuildOnScanSuccessStatus";
-import { CloudFoundryProductionDeployOnFingerprint } from "./blueprint/deploy/cloudFoundryDeploy";
+import {
+    CloudFoundryProductionDeployOnFingerprint,
+    CloudFoundryStagingDeployOnImageLinked
+} from "./blueprint/deploy/cloudFoundryDeploy";
 import { DeployToProd } from "./blueprint/deploy/deployToProd";
 import { DescribeStagingAndProd } from "./blueprint/deploy/describeRunningServices";
 import { LocalMavenDeployOnImageLinked } from "./blueprint/deploy/mavenDeploy";
@@ -42,7 +45,8 @@ export class SpringPCFSoftwareDeliveryMachine extends AbstractSoftwareDeliveryMa
 
     public builder: Maker<StatusSuccessHandler> = LocalMavenBuildOnSucessStatus;
 
-    public deploy1: Maker<HandleEvent<OnImageLinked.Subscription>> = () => LocalMavenDeployer;
+    public deploy1: Maker<HandleEvent<OnImageLinked.Subscription>> =
+        CloudFoundryStagingDeployOnImageLinked;//LocalMavenDeployer;
 
     public verifyEndpoint: Maker<VerifyOnEndpointStatus> = LookFor200OnEndpointRootGet;
 

--- a/src/software-delivery-machine/blueprint/phase/phaseManagement.ts
+++ b/src/software-delivery-machine/blueprint/phase/phaseManagement.ts
@@ -10,13 +10,14 @@ import {
 import { Phases } from "../../../handlers/events/delivery/Phases";
 import { HttpServicePhases } from "../../../handlers/events/delivery/phases/httpServicePhases";
 import { LibraryPhases } from "../../../handlers/events/delivery/phases/libraryPhases";
+import { ManifestPath } from "../../../handlers/events/delivery/deploy/pcf/CloudFoundryTarget";
 
 export const PhaseSetup = () => new SetupPhasesOnPush([jvmPhaseBuilder], PushesToMaster);
 
 async function jvmPhaseBuilder(p: GitProject): Promise<Phases> {
     try {
         const f = await p.findFile("pom.xml");
-        const manifest = await p.findFile("manifest.yml").catch(err => undefined);
+        const manifest = await p.findFile(ManifestPath).catch(err => undefined);
         const contents = await f.getContent();
         if (contents.includes("spring-boot") && !!manifest) {
             return HttpServicePhases;

--- a/src/software-delivery-machine/blueprint/phase/phaseManagement.ts
+++ b/src/software-delivery-machine/blueprint/phase/phaseManagement.ts
@@ -4,7 +4,7 @@ import { GitProject } from "@atomist/automation-client/project/git/GitProject";
 import { FailDownstreamPhasesOnPhaseFailure } from "../../../handlers/events/delivery/FailDownstreamPhasesOnPhaseFailure";
 import {
     ApplyPhasesParameters,
-    applyPhasesToCommit, PushesToMaster,
+    applyPhasesToCommit, PhaseCreator, PushesToMaster,
     SetupPhasesOnPush,
 } from "../../../handlers/events/delivery/phase/SetupPhasesOnPush";
 import { Phases } from "../../../handlers/events/delivery/Phases";
@@ -12,7 +12,7 @@ import { HttpServicePhases } from "../../../handlers/events/delivery/phases/http
 import { LibraryPhases } from "../../../handlers/events/delivery/phases/libraryPhases";
 import { ManifestPath } from "../../../handlers/events/delivery/deploy/pcf/CloudFoundryTarget";
 
-export const PhaseSetup = () => new SetupPhasesOnPush([jvmPhaseBuilder], PushesToMaster);
+export const PhaseSetup = () => new SetupPhasesOnPush(new PhaseCreator([jvmPhaseBuilder], PushesToMaster));
 
 async function jvmPhaseBuilder(p: GitProject): Promise<Phases> {
     try {

--- a/src/software-delivery-machine/commands/editors/addCloudFoundryManifest.ts
+++ b/src/software-delivery-machine/commands/editors/addCloudFoundryManifest.ts
@@ -2,6 +2,7 @@ import { HandleCommand } from "@atomist/automation-client";
 import { SimpleProjectEditor } from "@atomist/automation-client/operations/edit/projectEditor";
 import { editor } from "../../../handlers/commands/editors/registerEditor";
 import { identification } from "../../../handlers/events/delivery/build/local/maven/pomParser";
+import { ManifestPath } from "../../../handlers/events/delivery/deploy/pcf/CloudFoundryTarget";
 
 export const AddCloudFoundryManifestEditorName = "AddCloudFoundryManifest";
 
@@ -14,7 +15,7 @@ export const addCfManifest: SimpleProjectEditor = (p, ctx) => {
         .then(pom => pom.getContent()
             .then(content => identification(content))
             .then(ident => {
-                return p.addFile("manifest.yml", javaManifestFor(ident.artifact, ctx.teamId));
+                return p.addFile(ManifestPath, javaManifestFor(ident.artifact, ctx.teamId));
             }))
         .catch(err => p);
 };


### PR DESCRIPTION
Behaves the same as master, but makes changes necessary to be able to switch to the new `GitHubReleaseArtifactStore`.

*Note this new implementation is not presently working, because asset upload to a GitHub release is failing.*

- Adds GitHub tag and release code
- Adds GitHub `ArtifactStore` implementation
- Changes various signatures to pass GitHub credentials
- Cleans up a leaky abstraction in command line Cloud Foundry deployer, which relied on a local directory being present already
- Switch to builder pattern in `AbstractSoftwareDeliveryMachine` for `supportingCommands`
- Started documentation in readme