### PR TITLE
work to accommodate k8s triggers

### DIFF
--- a/graphql/subscription/OnAParticularStatus.graphql
+++ b/graphql/subscription/OnAParticularStatus.graphql
@@ -1,0 +1,39 @@
+
+subscription OnAParticularStatus($context: String!)  {
+    Status(context: $context) {
+        commit {
+            sha
+            message
+            statuses {
+                context
+                description
+                state
+                targetUrl
+            }
+            repo {
+                owner
+                name
+                channels {
+                    name
+                    id
+                }
+                org {
+                    chatTeam {
+                        id
+                    }
+                }
+            }
+            pushes {
+                branch
+            }
+            image {
+                image
+                imageName
+            }
+        }
+        state
+        targetUrl
+        context
+        description
+    }
+}

--- a/graphql/subscription/OnAnySuccessStatus.graphql
+++ b/graphql/subscription/OnAnySuccessStatus.graphql
@@ -8,6 +8,7 @@ subscription OnAnySuccessStatus {
                 context
                 description
                 state
+                targetUrl
             }
             repo {
                 owner
@@ -24,6 +25,10 @@ subscription OnAnySuccessStatus {
             }
             pushes {
                 branch
+            }
+            image {
+                image
+                imageName
             }
         }
         state

--- a/graphql/subscription/OnDeployToProductionFingerprint.graphql
+++ b/graphql/subscription/OnDeployToProductionFingerprint.graphql
@@ -20,6 +20,7 @@ subscription OnDeployToProductionFingerprint {
                 context
                 description
                 state
+                targetUrl
             }
             repo {
                 owner

--- a/graphql/subscription/OnSuccessStatus.graphql
+++ b/graphql/subscription/OnSuccessStatus.graphql
@@ -25,10 +25,6 @@ subscription OnSuccessStatus($context: String!) {
             pushes {
                 branch
             }
-            image {
-                image
-                imageName
-            }
         }
         state
         targetUrl

--- a/graphql/subscription/OnSuccessStatus.graphql
+++ b/graphql/subscription/OnSuccessStatus.graphql
@@ -25,6 +25,10 @@ subscription OnSuccessStatus($context: String!) {
             pushes {
                 branch
             }
+            image {
+                image
+                imageName
+            }
         }
         state
         targetUrl

--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -14,8 +14,8 @@ const pj = require(`${appRoot.path}/package.json`);
 const token = process.env.GITHUB_TOKEN;
 
 const assembled = new MachineAssembler(
-   // new SpringPCFSoftwareDeliveryMachine({ useCheckstyle: false}),
-    new SpringK8sSoftwareDeliveryMachine(),
+    new SpringPCFSoftwareDeliveryMachine({ useCheckstyle: false}),
+   // new SpringK8sSoftwareDeliveryMachine(),
 );
 
 export const configuration: Configuration = {

--- a/src/atomist.config.ts
+++ b/src/atomist.config.ts
@@ -6,6 +6,7 @@ import { applyHttpServicePhases } from "./software-delivery-machine/blueprint/ph
 import { affirmationEditor } from "./software-delivery-machine/commands/editors/affirmationEditor";
 import { breakBuildEditor, unbreakBuildEditor } from "./software-delivery-machine/commands/editors/breakBuild";
 import { SpringPCFSoftwareDeliveryMachine } from "./software-delivery-machine/SpringPCFSoftwareDeliveryMachine";
+import { SpringK8sSoftwareDeliveryMachine } from "./software-delivery-machine/SpringK8sSoftwareDeliveryMachine";
 
 // tslint:disable-next-line:no-var-requires
 const pj = require(`${appRoot.path}/package.json`);
@@ -13,7 +14,8 @@ const pj = require(`${appRoot.path}/package.json`);
 const token = process.env.GITHUB_TOKEN;
 
 const assembled = new MachineAssembler(
-    new SpringPCFSoftwareDeliveryMachine({ useCheckstyle: false}),
+   // new SpringPCFSoftwareDeliveryMachine({ useCheckstyle: false}),
+    new SpringK8sSoftwareDeliveryMachine(),
 );
 
 export const configuration: Configuration = {

--- a/src/handlers/events/StatusSuccessHandler.ts
+++ b/src/handlers/events/StatusSuccessHandler.ts
@@ -7,8 +7,6 @@ import { Phases } from "./delivery/Phases";
  */
 export interface StatusSuccessHandler extends HandleEvent<OnAnySuccessStatus.Subscription> {
 
-    ourContext: string;
-
     /**
      * If all phases are needed
      */

--- a/src/handlers/events/delivery/ArtifactStore.ts
+++ b/src/handlers/events/delivery/ArtifactStore.ts
@@ -1,6 +1,6 @@
 import { ProjectOperationCredentials } from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
-import { AppInfo } from "./deploy/Deployment";
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
+import { AppInfo } from "./deploy/Deployment";
 
 export interface ArtifactStore {
 

--- a/src/handlers/events/delivery/Phases.ts
+++ b/src/handlers/events/delivery/Phases.ts
@@ -104,17 +104,19 @@ export interface GitHubStatus {
     state?: StatusState;
     targetUrl?: string;
 }
-export interface GitHubStatusAndFriends extends GitHubStatus{
-    siblings: Array<GitHubStatus>;
+export interface GitHubStatusAndFriends extends GitHubStatus {
+    siblings: GitHubStatus[];
 }
 
 export function currentPhaseIsStillPending(currentPhase: GitHubStatusContext, status: GitHubStatusAndFriends): boolean {
     const result = status.siblings.find(s => s.state === "pending" && s.context === currentPhase);
     if (!result) {
         console.log(`${currentPhase} wanted to run but it wasn't pending`);
+        return false;
     }
     if (!result.description.startsWith("Planning")) {
-        console.log(`${currentPhase} is not still planned, so I'm not running it. Description: ${result.description}`)
+        console.log(`${currentPhase} is not still planned, so I'm not running it. Description: ${result.description}`);
+        return false;
     }
     return true;
 }

--- a/src/handlers/events/delivery/artifact/github/GitHubReleaseArtifactStore.ts
+++ b/src/handlers/events/delivery/artifact/github/GitHubReleaseArtifactStore.ts
@@ -1,19 +1,19 @@
+import { logger } from "@atomist/automation-client";
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import {
     ProjectOperationCredentials,
     TokenCredentials,
 } from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
+import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
+import * as GitHubApi from "@octokit/rest";
+import axios from "axios";
+import * as fs from "fs";
+import * as p from "path";
+import * as tmp from "tmp-promise";
+import * as URL from "url";
 import { createRelease, createTag, Release, Tag } from "../../../../commands/editors/toclient/ghub";
 import { ArtifactStore, DeployableArtifact } from "../../ArtifactStore";
 import { AppInfo } from "../../deploy/Deployment";
-import * as tmp from "tmp-promise";
-import * as p from "path";
-import axios from "axios";
-import * as GitHubApi from "@octokit/rest";
-import * as fs from "fs";
-import * as URL from "url";
-import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
-import { logger } from "@atomist/automation-client";
 
 export class GitHubReleaseArtifactStore implements ArtifactStore {
 
@@ -87,8 +87,8 @@ function saveFileAs(token: string, url: string, outputFilename: string): Promise
     return axios.get(url, {
         headers: {
             // TODO why doesn't auth work?
-            //"Authorization": `token ${token}`,
-            Accept: "application/octet-stream",
+            // "Authorization": `token ${token}`,
+            "Accept": "application/octet-stream",
             "Content-Type": "application/zip",
         },
         responseType: "arraybuffer",

--- a/src/handlers/events/delivery/build/BuildCompleteOnImageLinked.ts
+++ b/src/handlers/events/delivery/build/BuildCompleteOnImageLinked.ts
@@ -18,8 +18,8 @@ import { GraphQL, HandlerResult, Secret, Secrets, success, Success } from "@atom
 import { EventFired, EventHandler, HandleEvent, HandlerContext } from "@atomist/automation-client/Handlers";
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import { OnImageLinked } from "../../../../typings/types";
-import { PlannedPhase } from "../Phases";
 import { createStatus } from "../../../commands/editors/toclient/ghub";
+import { PlannedPhase } from "../Phases";
 
 /**
  * Deploy a published artifact identified in an ImageLinked event.
@@ -54,7 +54,7 @@ export class FindArtifactOnImageLinked implements HandleEvent<OnImageLinked.Subs
             state: "success",
             description: `Complete: ${params.artifactPhase.name}`,
             target_url: image.imageName,
-            context: params.artifactPhase.context
-        }).then(success)
+            context: params.artifactPhase.context,
+        }).then(success);
     }
 }

--- a/src/handlers/events/delivery/build/BuildCompleteOnImageLinked.ts
+++ b/src/handlers/events/delivery/build/BuildCompleteOnImageLinked.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GraphQL, HandlerResult, Secret, Secrets, success, Success } from "@atomist/automation-client";
+import { EventFired, EventHandler, HandleEvent, HandlerContext } from "@atomist/automation-client/Handlers";
+import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
+import { OnImageLinked } from "../../../../typings/types";
+import { PlannedPhase } from "../Phases";
+import { createStatus } from "../../../commands/editors/toclient/ghub";
+
+/**
+ * Deploy a published artifact identified in an ImageLinked event.
+ */
+@EventHandler("Set build phase to complete with link to artifact",
+    GraphQL.subscriptionFromFile("graphql/subscription/OnImageLinked.graphql"))
+export class BuildCompleteOnImageLinked implements HandleEvent<OnImageLinked.Subscription> {
+
+    @Secret(Secrets.OrgToken)
+    private githubToken: string;
+
+    /**
+     * The phase to update when an artifact is linked.
+     * When an artifact is linked to a commit, the build must be done.
+     */
+    constructor(private buildPhase: PlannedPhase) {
+    }
+
+    public handle(event: EventFired<OnImageLinked.Subscription>, ctx: HandlerContext, params: this): Promise<HandlerResult> {
+        const imageLinked = event.data.ImageLinked[0];
+        const commit = imageLinked.commit;
+        const image = imageLinked.image;
+        const id = new GitHubRepoRef(commit.repo.owner, commit.repo.name, commit.sha);
+
+        const builtStatus = commit.statuses.find(status => status.context === params.buildPhase.context);
+        if (!builtStatus) {
+            console.log(`Deploy: builtStatus not found`);
+            return Promise.resolve(Success);
+        }
+
+        return createStatus(params.githubToken, id, {
+            state: "success",
+            description: `${params.buildPhase.name} artifact: ${image.imageName}`,
+            target_url: image.image,
+            context: params.buildPhase.context
+        }).then(success)
+    }
+}

--- a/src/handlers/events/delivery/build/BuildOnScanSuccessStatus.ts
+++ b/src/handlers/events/delivery/build/BuildOnScanSuccessStatus.ts
@@ -20,7 +20,7 @@ import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitH
 import { OnAnySuccessStatus } from "../../../../typings/types";
 import { addressChannelsFor } from "../../../commands/editors/toclient/addressChannels";
 import { StatusSuccessHandler } from "../../StatusSuccessHandler";
-import { currentPhaseIsStillPending, nothingFailed, Phases, previousPhaseSucceeded } from "../Phases";
+import { currentPhaseIsStillPending, GitHubStatusAndFriends, nothingFailed, Phases, previousPhaseSucceeded } from "../Phases";
 import { Builder } from "./Builder";
 
 /**
@@ -43,10 +43,11 @@ export class BuildOnScanSuccessStatus implements StatusSuccessHandler {
         const commit = status.commit;
         const team = commit.repo.org.chatTeam.id;
 
-        const statusAndFriends = {
+        const statusAndFriends : GitHubStatusAndFriends = {
             context: status.context,
             state: status.state,
             targetUrl: status.targetUrl,
+            description: status.description,
             siblings: status.commit.statuses,
         };
 

--- a/src/handlers/events/delivery/build/BuildOnScanSuccessStatus.ts
+++ b/src/handlers/events/delivery/build/BuildOnScanSuccessStatus.ts
@@ -61,6 +61,8 @@ export class BuildOnScanSuccessStatus implements StatusSuccessHandler {
         const id = new GitHubRepoRef(commit.repo.owner, commit.repo.name, commit.sha);
         const creds = {token: params.githubToken};
 
+        // the builder is expected to result in a complete Build event (which will update the build status)
+        // and an ImageLinked event (which will update the artifact status).
         await params.builder.initiateBuild(creds, id, addressChannelsFor(commit.repo, ctx), team);
         return Success;
     }

--- a/src/handlers/events/delivery/build/k8s/K8AutomationBuilder.ts
+++ b/src/handlers/events/delivery/build/k8s/K8AutomationBuilder.ts
@@ -1,10 +1,9 @@
-import {AddressChannels} from "../../../../commands/editors/toclient/addressChannels";
+import {success} from "@atomist/automation-client";
+import {GitHubRepoRef} from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import {ProjectOperationCredentials, TokenCredentials} from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
 import {RemoteRepoRef} from "@atomist/automation-client/operations/common/RepoId";
+import {AddressChannels} from "../../../../commands/editors/toclient/addressChannels";
 import {createStatus} from "../../../../commands/editors/toclient/ghub";
-import {GitHubRepoRef} from "@atomist/automation-client/operations/common/GitHubRepoRef";
-import {success} from "@atomist/automation-client";
-
 
 const K8AutomationBuildContext = "build/atomist/k8s";
 /**
@@ -15,9 +14,9 @@ const K8AutomationBuildContext = "build/atomist/k8s";
  * The message to k8-automation takes the form of a pending GitHub status.
  */
 export function initiatek8AutomationBuild(creds: ProjectOperationCredentials,
-    id: RemoteRepoRef,
-    ac: AddressChannels,
-    team: string): Promise<any> {
+                                          id: RemoteRepoRef,
+                                          ac: AddressChannels,
+                                          team: string): Promise<any> {
 
     return createStatus((creds as TokenCredentials).token, id as GitHubRepoRef, {
         context: K8AutomationBuildContext,
@@ -25,4 +24,4 @@ export function initiatek8AutomationBuild(creds: ProjectOperationCredentials,
         description: "Requested build in k8-automation",
         target_url: undefined,
     }).then(success);
-};
+}

--- a/src/handlers/events/delivery/build/k8s/K8AutomationBuilder.ts
+++ b/src/handlers/events/delivery/build/k8s/K8AutomationBuilder.ts
@@ -4,6 +4,7 @@ import {ProjectOperationCredentials, TokenCredentials} from "@atomist/automation
 import {RemoteRepoRef} from "@atomist/automation-client/operations/common/RepoId";
 import {AddressChannels} from "../../../../commands/editors/toclient/addressChannels";
 import {createStatus} from "../../../../commands/editors/toclient/ghub";
+import { Builder } from "../Builder";
 
 const K8AutomationBuildContext = "build/atomist/k8s";
 /**
@@ -13,15 +14,13 @@ const K8AutomationBuildContext = "build/atomist/k8s";
  *
  * The message to k8-automation takes the form of a pending GitHub status.
  */
-export function initiatek8AutomationBuild(creds: ProjectOperationCredentials,
-                                          id: RemoteRepoRef,
-                                          ac: AddressChannels,
-                                          team: string): Promise<any> {
-
-    return createStatus((creds as TokenCredentials).token, id as GitHubRepoRef, {
-        context: K8AutomationBuildContext,
-        state: "pending",
-        description: "Requested build in k8-automation",
-        target_url: undefined,
-    }).then(success);
+export class K8sAutomationBuilder implements Builder {
+    initiateBuild(creds: ProjectOperationCredentials, id: RemoteRepoRef, ac: AddressChannels, team: string): Promise<any> {
+        return createStatus((creds as TokenCredentials).token, id as GitHubRepoRef, {
+            context: K8AutomationBuildContext,
+            state: "pending",
+            description: "Requested build in k8-automation",
+            target_url: undefined,
+        }).then(success);
+    }
 }

--- a/src/handlers/events/delivery/build/k8s/K8AutomationBuilder.ts
+++ b/src/handlers/events/delivery/build/k8s/K8AutomationBuilder.ts
@@ -1,0 +1,28 @@
+import {AddressChannels} from "../../../../commands/editors/toclient/addressChannels";
+import {ProjectOperationCredentials, TokenCredentials} from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
+import {RemoteRepoRef} from "@atomist/automation-client/operations/common/RepoId";
+import {createStatus} from "../../../../commands/editors/toclient/ghub";
+import {GitHubRepoRef} from "@atomist/automation-client/operations/common/GitHubRepoRef";
+import {success} from "@atomist/automation-client";
+
+
+const K8AutomationBuildContext = "build/atomist/k8s";
+/**
+ * Upon recognizing a plan to create an artifact, send a message to k8-automation to request a build.
+ * k8-automation will trigger a build for this commit in Google Container Builder.
+ * When that is complete, it will send an ImageLinked event, and that means our artifact has been created.
+ *
+ * The message to k8-automation takes the form of a pending GitHub status.
+ */
+export function initiatek8AutomationBuild(creds: ProjectOperationCredentials,
+    id: RemoteRepoRef,
+    ac: AddressChannels,
+    team: string): Promise<any> {
+
+    return createStatus((creds as TokenCredentials).token, id as GitHubRepoRef, {
+        context: K8AutomationBuildContext,
+        state: "pending",
+        description: "Requested build in k8-automation",
+        target_url: undefined,
+    }).then(success);
+};

--- a/src/handlers/events/delivery/deploy/DeployFromLocalOnFingerprint.ts
+++ b/src/handlers/events/delivery/deploy/DeployFromLocalOnFingerprint.ts
@@ -60,6 +60,7 @@ export class DeployFromLocalOnFingerprint<T extends TargetInfo> implements Handl
         const statusAndFriends: GitHubStatusAndFriends = {
             context: BuildContext,
             state: "success", // builtStatus.state,
+            description: "This is sadly hardcoded",
             targetUrl: "xxx",
             siblings: fingerprint.commit.statuses,
         };

--- a/src/handlers/events/delivery/deploy/DeployFromLocalOnFingerprint.ts
+++ b/src/handlers/events/delivery/deploy/DeployFromLocalOnFingerprint.ts
@@ -26,7 +26,7 @@ import {
     PlannedPhase,
     previousPhaseSucceeded,
 } from "../Phases";
-import { BuiltContext } from "../phases/gitHubContext";
+import { BuildContext } from "../phases/gitHubContext";
 import { deploy } from "./deploy";
 import { Deployer } from "./Deployer";
 import { TargetInfo } from "./Deployment";
@@ -52,13 +52,13 @@ export class DeployFromLocalOnFingerprint<T extends TargetInfo> implements Handl
         const commit = fingerprint.commit;
 
         // TODO doesn't work as built status isn't in, yet
-        // const builtStatus = commit.statuses.find(status => status.context === BuiltContext);
+        // const builtStatus = commit.statuses.find(status => status.context === BuildContext);
         // if (!builtStatus) {
         //     console.log(`Deploy: builtStatus not found`);
         //     return Promise.resolve(Success);
         // }
         const statusAndFriends: GitHubStatusAndFriends = {
-            context: BuiltContext,
+            context: BuildContext,
             state: "success", // builtStatus.state,
             targetUrl: "xxx",
             siblings: fingerprint.commit.statuses,

--- a/src/handlers/events/delivery/deploy/DeployFromLocalOnImageLinked.ts
+++ b/src/handlers/events/delivery/deploy/DeployFromLocalOnImageLinked.ts
@@ -20,18 +20,11 @@ import { commandHandlerFrom } from "@atomist/automation-client/onCommand";
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import { buttonForCommand } from "@atomist/automation-client/spi/message/MessageClient";
-import { OnImageLinked, OnSuccessStatus } from "../../../../typings/types";
+import { OnAnySuccessStatus, OnSuccessStatus } from "../../../../typings/types";
 import { addressChannelsFor } from "../../../commands/editors/toclient/addressChannels";
 import { EventWithCommand, RetryDeployParameters } from "../../../commands/RetryDeploy";
 import { ArtifactStore } from "../ArtifactStore";
-import {
-    currentPhaseIsStillPending,
-    GitHubStatusAndFriends,
-    Phases,
-    PlannedPhase,
-    previousPhaseSucceeded,
-} from "../Phases";
-import { BuildContext } from "../phases/gitHubContext";
+import { currentPhaseIsStillPending, GitHubStatusAndFriends, Phases, PlannedPhase, previousPhaseSucceeded } from "../Phases";
 import { deploy } from "./deploy";
 import { Deployer } from "./Deployer";
 import { TargetInfo } from "./Deployment";
@@ -40,8 +33,8 @@ import { TargetInfo } from "./Deployment";
  * Deploy a published artifact identified in an ImageLinked event.
  */
 @EventHandler("Deploy linked artifact",
-    GraphQL.subscriptionFromFile("graphql/subscription/OnSuccessStatus.graphql"))
-export class DeployFromLocalOnSuccessStatus<T extends TargetInfo> implements HandleEvent<OnSuccessStatus.Subscription>, EventWithCommand {
+    GraphQL.subscriptionFromFile("graphql/subscription/OnAnySuccessStatus.graphql"))
+export class DeployFromLocalOnSuccessStatus<T extends TargetInfo> implements HandleEvent<OnAnySuccessStatus.Subscription>, EventWithCommand {
 
     @Secret(Secrets.OrgToken)
     private githubToken: string;
@@ -94,6 +87,7 @@ export class DeployFromLocalOnSuccessStatus<T extends TargetInfo> implements Han
         const commit = status.commit;
         const image = status.commit.image;
 
+        console.log("remove me");
 
         const retryButton = buttonForCommand({text: "Retry"}, this.commandName, {
             repo: commit.repo.name,
@@ -125,7 +119,7 @@ export class DeployFromLocalOnSuccessStatus<T extends TargetInfo> implements Han
 
         if (!image) {
             logger.warn(`No image found on commit ${commit.sha}; can't deploy`);
-            return Promise.resolve(failure(new Error("No image linked")))
+            return Promise.resolve(failure(new Error("No image linked")));
         }
 
         const id = new GitHubRepoRef(commit.repo.owner, commit.repo.name, commit.sha);

--- a/src/handlers/events/delivery/deploy/DeployFromLocalOnSuccessStatus.ts
+++ b/src/handlers/events/delivery/deploy/DeployFromLocalOnSuccessStatus.ts
@@ -98,13 +98,11 @@ export class DeployFromLocalOnSuccessStatus<T extends TargetInfo> implements Han
         };
 
         // TODO: continue as long as everything before me has succeeded, regardless of whether this is the triggering on
-        // (this is related to the next two TODOs)
+        // (this is related to the next TODO)
         if (!previousPhaseSucceeded(params.phases, params.ourPhase.context, statusAndFriends)) {
             return Promise.resolve(Success);
         }
 
-        // TODO: make sure it is in a "Planning" state, not just "pending" -- this lets us start the deploy after a failing status
-        // is corrected, but not too many times.
         if (!currentPhaseIsStillPending(params.ourPhase.context, statusAndFriends)) {
             return Promise.resolve(Success);
         }

--- a/src/handlers/events/delivery/deploy/OnDeployStatus.ts
+++ b/src/handlers/events/delivery/deploy/OnDeployStatus.ts
@@ -20,7 +20,7 @@ import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitH
 import { OnSuccessStatus } from "../../../../typings/types";
 import Status = OnSuccessStatus.Status;
 import { AddressChannels, addressChannelsFor } from "../../../commands/editors/toclient/addressChannels";
-import { CloudFoundryStagingDeploymentContext } from "../phases/httpServicePhases";
+import { StagingDeploymentContext } from "../phases/httpServicePhases";
 
 /**
  * React to a successful deployment
@@ -36,7 +36,7 @@ export type DeployListener = (id: GitHubRepoRef,
 @EventHandler("React to a successful deployment",
     GraphQL.subscriptionFromFile("graphql/subscription/OnSuccessStatus.graphql",
         undefined, {
-            context: CloudFoundryStagingDeploymentContext,
+            context: StagingDeploymentContext,
         }))
 export class OnDeployStatus implements HandleEvent<OnSuccessStatus.Subscription> {
 
@@ -54,7 +54,7 @@ export class OnDeployStatus implements HandleEvent<OnSuccessStatus.Subscription>
         const status = event.data.Status[0];
         const commit = status.commit;
 
-        if (status.context !== CloudFoundryStagingDeploymentContext) {
+        if (status.context !== StagingDeploymentContext) {
             console.log(`********* OnDeploy got called with status context=[${status.context}]`);
             return Promise.resolve(Success);
         }

--- a/src/handlers/events/delivery/deploy/k8s/NoticeK8sDeployCompletion.ts
+++ b/src/handlers/events/delivery/deploy/k8s/NoticeK8sDeployCompletion.ts
@@ -29,7 +29,7 @@ import { K8AutomationDeployContext } from "./RequestDeployOnSuccessStatus";
 @EventHandler("Request k8s deploy of linked artifact",
     GraphQL.subscriptionFromFile("graphql/subscription/OnAParticularStatus.graphql", undefined,
         {context: K8AutomationDeployContext}))
-export class RequestK8sDeployOnSuccessStatus implements HandleEvent<OnAParticularStatus.Subscription> {
+export class NoticeK8sDeployCompletionOnStatus implements HandleEvent<OnAParticularStatus.Subscription> {
 
     @Secret(Secrets.OrgToken)
     private githubToken: string;

--- a/src/handlers/events/delivery/deploy/k8s/NoticeK8sDeployCompletion.ts
+++ b/src/handlers/events/delivery/deploy/k8s/NoticeK8sDeployCompletion.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GraphQL, HandlerResult, logger, Secret, Secrets, Success } from "@atomist/automation-client";
+import { EventFired, EventHandler, HandleEvent, HandlerContext } from "@atomist/automation-client/Handlers";
+import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
+import { createStatus } from "../../../../commands/editors/toclient/ghub";
+import { OnAnySuccessStatus } from "../../../../../typings/types";
+import { PlannedPhase } from "../../Phases";
+import { K8AutomationDeployContext } from "./RequestDeployOnSuccessStatus";
+
+
+/**
+ * Deploy a published artifact identified in an ImageLinked event.
+ */
+@EventHandler("Request k8s deploy of linked artifact",
+    GraphQL.subscriptionFromFile("graphql/subscription/OnSuccessStatus.graphql", undefined,
+        {context: K8AutomationDeployContext}))
+export class RequestK8sDeployOnSuccessStatus implements HandleEvent<OnAnySuccessStatus.Subscription> {
+
+    @Secret(Secrets.OrgToken)
+    private githubToken: string;
+
+    /**
+     *
+     * @param {PlannedPhase} ourPhase
+     * @param {PlannedPhase} endpointPhase
+     */
+    constructor(private deployPhase: PlannedPhase,
+                private endpointPhase: PlannedPhase) {
+    }
+
+    public async handle(event: EventFired<OnAnySuccessStatus.Subscription>, ctx: HandlerContext, params: this): Promise<HandlerResult> {
+        const status = event.data.Status[0];
+        const commit = status.commit;
+
+        if (status.context !== K8AutomationDeployContext || status.state !== "success") {
+            logger.warn(`Unexpected event: ${status.context} is ${status.state}`);
+            return Promise.resolve(Success);
+        }
+
+        logger.info(`Recognized deploy. Triggered by ${status.state} status: ${status.context}: ${status.description}`);
+
+        const id = new GitHubRepoRef(commit.repo.owner, commit.repo.name, commit.sha);
+        await createStatus(params.githubToken, id as GitHubRepoRef, {
+            context: params.deployPhase.context,
+            state: "success",
+            description: "Complete: " + params.deployPhase.name,
+            target_url: undefined,
+        });
+        if (status.targetUrl) {
+            await createStatus(params.githubToken, id as GitHubRepoRef, {
+                context: params.endpointPhase.context,
+                state: "success",
+                description: "Complete: " + params.endpointPhase.name,
+                target_url: status.targetUrl,
+            });
+        } else {
+            logger.warn("no endpoint URL determined from " + status.context)
+        }
+        return Success;
+    }
+
+}
+
+

--- a/src/handlers/events/delivery/deploy/k8s/RequestDeployOnSuccessStatus.ts
+++ b/src/handlers/events/delivery/deploy/k8s/RequestDeployOnSuccessStatus.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { failure, GraphQL, HandlerResult, logger, Secret, Secrets, Success } from "@atomist/automation-client";
+import { EventFired, EventHandler, HandleEvent, HandlerContext } from "@atomist/automation-client/Handlers";
+import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
+import { createStatus } from "../../../../commands/editors/toclient/ghub";
+import { OnAnySuccessStatus } from "../../../../../typings/types";
+import { currentPhaseIsStillPending, GitHubStatusAndFriends, Phases, PlannedPhase, previousPhaseSucceeded } from "../../Phases";
+
+
+const K8AutomationDeployContext = "deploy/atomist/k8s/testing";
+
+/**
+ * Deploy a published artifact identified in an ImageLinked event.
+ */
+@EventHandler("Request k8s deploy of linked artifact",
+    GraphQL.subscriptionFromFile("graphql/subscription/OnAnySuccessStatus.graphql"))
+export class RequestK8sDeployOnSuccessStatus implements HandleEvent<OnAnySuccessStatus.Subscription> {
+
+    @Secret(Secrets.OrgToken)
+    private githubToken: string;
+
+    /**
+     *
+     * @param {Phases} phases
+     * @param {PlannedPhase} ourPhase
+     * @param {PlannedPhase} endpointPhase
+     * @param {ArtifactStore} artifactStore
+     * @param {Deployer<T extends TargetInfo>} deployer
+     * @param {(id: RemoteRepoRef) => T} targeter tells what target to use for this repo.
+     * For example, we may wish to deploy different repos to different Cloud Foundry spaces
+     * or Kubernetes clusters
+     */
+    constructor(private phases: Phases,
+                private ourPhase: PlannedPhase,
+                private endpointPhase: PlannedPhase) {
+    }
+
+    public async handle(event: EventFired<OnAnySuccessStatus.Subscription>, ctx: HandlerContext, params: this): Promise<HandlerResult> {
+        const status = event.data.Status[0];
+        const commit = status.commit;
+        const image = status.commit.image;
+
+        console.log("remove me");
+
+        const statusAndFriends: GitHubStatusAndFriends = {
+            context: status.context,
+            state: status.state,
+            targetUrl: status.targetUrl,
+            description: status.description,
+            siblings: status.commit.statuses,
+        };
+
+        // TODO: continue as long as everything before me has succeeded, regardless of whether this is the triggering on
+        // (this is related to the next two TODOs)
+        if (!previousPhaseSucceeded(params.phases, params.ourPhase.context, statusAndFriends)) {
+            return Promise.resolve(Success);
+        }
+
+        if (!currentPhaseIsStillPending(params.ourPhase.context, statusAndFriends)) {
+            return Promise.resolve(Success);
+        }
+
+        // TODO: if any status is failed, do not deploy
+
+        if (!image) {
+            logger.warn(`No image found on commit ${commit.sha}; can't deploy`);
+            return Promise.resolve(failure(new Error("No image linked")));
+        }
+
+        logger.info(`Requesting deploy. Triggered by ${status.state} status: ${status.context}: ${status.description}`);
+
+
+        const id = new GitHubRepoRef(commit.repo.owner, commit.repo.name, commit.sha);
+        await createStatus(params.githubToken, id as GitHubRepoRef, {
+            context: K8AutomationDeployContext,
+            state: "pending",
+            description: "Requested deploy by k8-automation",
+            target_url: image.imageName,
+        });
+        return Success;
+    }
+
+}
+
+

--- a/src/handlers/events/delivery/deploy/pcf/CommandLineCloudFoundryDeployer.ts
+++ b/src/handlers/events/delivery/deploy/pcf/CommandLineCloudFoundryDeployer.ts
@@ -1,6 +1,6 @@
 import { logger } from "@atomist/automation-client";
 import { runCommand } from "@atomist/automation-client/action/cli/commandLine";
-import { ProjectOperationCredentials, } from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
+import { ProjectOperationCredentials } from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
 import { GitCommandGitProject } from "@atomist/automation-client/project/git/GitCommandGitProject";
 import { spawn } from "child_process";
 import { DeployableArtifact } from "../../ArtifactStore";
@@ -27,7 +27,7 @@ export class CommandLineCloudFoundryDeployer implements Deployer<CloudFoundryInf
         const manifestFile = await sources.findFile(ManifestPath);
 
         if (!cfi.api || !cfi.org || !cfi.username || !cfi.password) {
-            throw new Error("cloud foundry authentication information missing. See CloudFoundryTarget.ts")
+            throw new Error("cloud foundry authentication information missing. See CloudFoundryTarget.ts");
         }
 
         // TODO: if the password is wrong, things hangs forever waiting for input.
@@ -67,8 +67,8 @@ export class CommandLineCloudFoundryDeployer implements Deployer<CloudFoundryInf
         return {
             relevantPart: "",
             message: "Deploy failed",
-            includeFullLog: true
-        }
+            includeFullLog: true,
+        };
     }
 
 }

--- a/src/handlers/events/delivery/phases/gitHubContext.ts
+++ b/src/handlers/events/delivery/phases/gitHubContext.ts
@@ -10,7 +10,8 @@ export const StagingEnvironment = "1-staging/";
 export const ProductionEnvironment = "2-prod/";
 
 export const ScanContext = BaseContext + IndependentOfEnvironment + "1-scan";
-export const BuiltContext = BaseContext + IndependentOfEnvironment + "2-build";
+export const BuildContext = BaseContext + IndependentOfEnvironment + "2-build";
+export const ArtifactContext = BaseContext + IndependentOfEnvironment + "2.5-artifact";
 
 /**
  * if this is a context we created, then we can interpret it.

--- a/src/handlers/events/delivery/phases/httpServicePhases.ts
+++ b/src/handlers/events/delivery/phases/httpServicePhases.ts
@@ -1,5 +1,5 @@
 import { Phases, PlannedPhase } from "../Phases";
-import { BaseContext, BuiltContext, ScanContext, StagingEnvironment } from "./gitHubContext";
+import { ArtifactContext, BaseContext, BuildContext, ScanContext, StagingEnvironment } from "./gitHubContext";
 
 export const CloudFoundryStagingDeploymentContext = BaseContext + StagingEnvironment + "3-PCF deploy";
 export const StagingEndpointContext = BaseContext + StagingEnvironment + "4-endpoint";
@@ -7,13 +7,14 @@ export const StagingVerifiedContext = BaseContext + StagingEnvironment + "5-veri
 
 export const ContextToPlannedPhase: { [key: string]: PlannedPhase } = {};
 ContextToPlannedPhase[ScanContext] = {context: ScanContext, name: "scan"};
-ContextToPlannedPhase[BuiltContext] = {context: BuiltContext, name: "build"};
+ContextToPlannedPhase[BuildContext] = {context: BuildContext, name: "build"};
+ContextToPlannedPhase[ArtifactContext] = {context: ArtifactContext, name: "find artifact"};
 ContextToPlannedPhase[CloudFoundryStagingDeploymentContext] = {
     context: CloudFoundryStagingDeploymentContext,
-    name: "deploy to staging",
+    name: "deploy to Test space in PCF",
 };
-ContextToPlannedPhase[StagingEndpointContext] = {context: StagingEndpointContext, name: "find endpoint in staging"};
-ContextToPlannedPhase[StagingVerifiedContext] = {context: StagingVerifiedContext, name: "verify endpoint in staging"};
+ContextToPlannedPhase[StagingEndpointContext] = {context: StagingEndpointContext, name: "find endpoint in Test"};
+ContextToPlannedPhase[StagingVerifiedContext] = {context: StagingVerifiedContext, name: "verify endpoint in Test"};
 
 /**
  * Phases for an Http service
@@ -21,7 +22,8 @@ ContextToPlannedPhase[StagingVerifiedContext] = {context: StagingVerifiedContext
  */
 export const HttpServicePhases = new Phases([
     ScanContext,
-    BuiltContext,
+    BuildContext,
+    ArtifactContext,
     CloudFoundryStagingDeploymentContext,
     StagingEndpointContext,
     StagingVerifiedContext]);

--- a/src/handlers/events/delivery/phases/httpServicePhases.ts
+++ b/src/handlers/events/delivery/phases/httpServicePhases.ts
@@ -1,7 +1,7 @@
 import { Phases, PlannedPhase } from "../Phases";
 import { ArtifactContext, BaseContext, BuildContext, ScanContext, StagingEnvironment } from "./gitHubContext";
 
-export const CloudFoundryStagingDeploymentContext = BaseContext + StagingEnvironment + "3-PCF deploy";
+export const StagingDeploymentContext = BaseContext + StagingEnvironment + "3-deploy";
 export const StagingEndpointContext = BaseContext + StagingEnvironment + "4-endpoint";
 export const StagingVerifiedContext = BaseContext + StagingEnvironment + "5-verifyEndpoint";
 
@@ -9,9 +9,9 @@ export const ContextToPlannedPhase: { [key: string]: PlannedPhase } = {};
 ContextToPlannedPhase[ScanContext] = {context: ScanContext, name: "scan"};
 ContextToPlannedPhase[BuildContext] = {context: BuildContext, name: "build"};
 ContextToPlannedPhase[ArtifactContext] = {context: ArtifactContext, name: "find artifact"};
-ContextToPlannedPhase[CloudFoundryStagingDeploymentContext] = {
-    context: CloudFoundryStagingDeploymentContext,
-    name: "deploy to Test space in PCF",
+ContextToPlannedPhase[StagingDeploymentContext] = {
+    context: StagingDeploymentContext,
+    name: "deploy to Test space",
 };
 ContextToPlannedPhase[StagingEndpointContext] = {context: StagingEndpointContext, name: "find endpoint in Test"};
 ContextToPlannedPhase[StagingVerifiedContext] = {context: StagingVerifiedContext, name: "verify endpoint in Test"};
@@ -24,6 +24,6 @@ export const HttpServicePhases = new Phases([
     ScanContext,
     BuildContext,
     ArtifactContext,
-    CloudFoundryStagingDeploymentContext,
+    StagingDeploymentContext,
     StagingEndpointContext,
     StagingVerifiedContext]);

--- a/src/handlers/events/delivery/phases/libraryPhases.ts
+++ b/src/handlers/events/delivery/phases/libraryPhases.ts
@@ -1,7 +1,7 @@
 import { Phases } from "../Phases";
-import { BuiltContext, ScanContext } from "./gitHubContext";
+import { BuildContext, ScanContext } from "./gitHubContext";
 
 export const LibraryPhases = new Phases([
     ScanContext,
-    BuiltContext,
+    BuildContext,
 ]);

--- a/src/handlers/events/delivery/review/checkStyleReportToReview.ts
+++ b/src/handlers/events/delivery/review/checkStyleReportToReview.ts
@@ -2,8 +2,8 @@ import { RepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import { ProjectReview, ReviewComment } from "@atomist/automation-client/operations/review/ReviewResult";
 import { CheckstyleReport, FileReport } from "./CheckstyleReport";
 
-import * as _ from "lodash";
 import { logger } from "@atomist/automation-client";
+import * as _ from "lodash";
 
 export function checkstyleReportToReview(repoId: RepoRef,
                                          cr: CheckstyleReport,

--- a/src/handlers/events/delivery/verify/VerifyOnEndpointStatus.ts
+++ b/src/handlers/events/delivery/verify/VerifyOnEndpointStatus.ts
@@ -20,7 +20,7 @@ import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitH
 import { OnSuccessStatus, StatusState } from "../../../../typings/types";
 import { AddressChannels, addressChannelsFor } from "../../../commands/editors/toclient/addressChannels";
 import { createStatus } from "../../../commands/editors/toclient/ghub";
-import { currentPhaseIsStillPending, previousPhaseSucceeded } from "../Phases";
+import { currentPhaseIsStillPending, GitHubStatusAndFriends, previousPhaseSucceeded } from "../Phases";
 import {
     ContextToPlannedPhase,
     HttpServicePhases,
@@ -60,8 +60,9 @@ export class VerifyOnEndpointStatus implements HandleEvent<OnSuccessStatus.Subsc
         const status = event.data.Status[0];
         const commit = status.commit;
 
-        const statusAndFriends = {
+        const statusAndFriends: GitHubStatusAndFriends = {
             context: status.context,
+            description: status.description,
             state: status.state,
             targetUrl: status.targetUrl,
             siblings: status.commit.statuses,

--- a/src/handlers/events/link/ImageLink.ts
+++ b/src/handlers/events/link/ImageLink.ts
@@ -138,6 +138,7 @@ export function postWebhook(
     teamId: string,
     retryOptions = DefaultRetryOptions,
 ): Promise<boolean> {
+    logger.info("Posting webhook: " + payload);
 
     const baseUrl = process.env.ATOMIST_WEBHOOK_BASEURL || "https://webhook.atomist.com";
     const url = `${baseUrl}/atomist/${webhook}/teams/${teamId}`;

--- a/src/sdm/AbstractSoftwareDeliveryMachine.ts
+++ b/src/sdm/AbstractSoftwareDeliveryMachine.ts
@@ -10,7 +10,7 @@ import { OnSuperseded, SupersededListener } from "../handlers/events/delivery/ph
 import { SetSupersededStatus } from "../handlers/events/delivery/phase/SetSupersededStatus";
 import { SetupPhasesOnPush } from "../handlers/events/delivery/phase/SetupPhasesOnPush";
 import { Phases } from "../handlers/events/delivery/Phases";
-import { BuiltContext } from "../handlers/events/delivery/phases/gitHubContext";
+import { BuildContext } from "../handlers/events/delivery/phases/gitHubContext";
 import {
     CodeReaction,
     WithCodeOnPendingScanStatus,
@@ -25,7 +25,7 @@ import {
     ReactToSemanticDiffsOnPushImpact,
 } from "../handlers/events/repo/ReactToSemanticDiffsOnPushImpact";
 import { StatusSuccessHandler } from "../handlers/events/StatusSuccessHandler";
-import { OnImageLinked } from "../typings/types";
+import { OnImageLinked, OnSuccessStatus } from "../typings/types";
 import { PromotedEnvironment } from "./ReferenceDeliveryBlueprint";
 import { SoftwareDeliveryMachine } from "./SoftwareDeliveryMachine";
 
@@ -105,9 +105,9 @@ export abstract class AbstractSoftwareDeliveryMachine implements SoftwareDeliver
 
     public abstract builder: Maker<StatusSuccessHandler>;
 
-    public buildCompleter: Maker<HandleEvent<OnImageLinked.Subscription> & EventWithCommand>
+    public artifactFinder: Maker<HandleEvent<OnImageLinked.Subscription>>;
 
-    public abstract deploy1: Maker<HandleEvent<OnImageLinked.Subscription> & EventWithCommand>;
+    public abstract deploy1: Maker<HandleEvent<OnSuccessStatus.Subscription> & EventWithCommand>;
 
     public get notifyOnDeploy(): Maker<OnDeployStatus> {
         return this.deploymentListeners.length > 0 ?
@@ -122,7 +122,7 @@ export abstract class AbstractSoftwareDeliveryMachine implements SoftwareDeliver
     public abstract promotedEnvironment?: PromotedEnvironment;
 
     public onBuildComplete: Maker<SetStatusOnBuildComplete> =
-        () => new SetStatusOnBuildComplete(BuiltContext)
+        () => new SetStatusOnBuildComplete(BuildContext)
 
     get eventHandlers(): Array<Maker<HandleEvent<any>>> {
         return (this.phaseCleanup as Array<Maker<HandleEvent<any>>>)
@@ -142,6 +142,7 @@ export abstract class AbstractSoftwareDeliveryMachine implements SoftwareDeliver
                 this.notifyOnDeploy,
                 this.verifyEndpoint,
                 this.onVerifiedStatus,
+                this.artifactFinder,
             ]).filter(m => !!m);
     }
 

--- a/src/sdm/AbstractSoftwareDeliveryMachine.ts
+++ b/src/sdm/AbstractSoftwareDeliveryMachine.ts
@@ -105,6 +105,8 @@ export abstract class AbstractSoftwareDeliveryMachine implements SoftwareDeliver
 
     public abstract builder: Maker<StatusSuccessHandler>;
 
+    public buildCompleter: Maker<HandleEvent<OnImageLinked.Subscription> & EventWithCommand>
+
     public abstract deploy1: Maker<HandleEvent<OnImageLinked.Subscription> & EventWithCommand>;
 
     public get notifyOnDeploy(): Maker<OnDeployStatus> {

--- a/src/sdm/AbstractSoftwareDeliveryMachine.ts
+++ b/src/sdm/AbstractSoftwareDeliveryMachine.ts
@@ -39,6 +39,7 @@ export abstract class AbstractSoftwareDeliveryMachine implements SoftwareDeliver
     public editors: Array<Maker<HandleCommand>> = [];
 
     public supportingCommands: Array<Maker<HandleCommand>> = [];
+    public supportingEvents: Array<Maker<HandleEvent<any>>> = [];
 
     private newRepoWithCodeActions: NewRepoWithCodeAction[] = [];
 
@@ -170,6 +171,11 @@ export abstract class AbstractSoftwareDeliveryMachine implements SoftwareDeliver
 
     public addSupportingCommands(...e: Array<Maker<HandleCommand>>): this {
         this.supportingCommands = this.supportingCommands.concat(e);
+        return this;
+    }
+
+    public addSupportingEvents(...e: Array<Maker<HandleEvent<any>>>): this {
+        this.supportingEvents = this.supportingEvents.concat(e);
         return this;
     }
 

--- a/src/sdm/ReferenceDeliveryBlueprint.ts
+++ b/src/sdm/ReferenceDeliveryBlueprint.ts
@@ -18,6 +18,9 @@ import {
     OnSupersededStatus,
 } from "../typings/types";
 import { FunctionalUnit } from "./FunctionalUnit";
+import { ContextToPlannedPhase } from "../handlers/events/delivery/phases/httpServicePhases";
+import { ArtifactContext } from "../handlers/events/delivery/phases/gitHubContext";
+import { FindArtifactOnImageLinked } from "../handlers/events/delivery/build/BuildCompleteOnImageLinked";
 
 /**
  * An environment to promote into. Normally there is only one, for production
@@ -69,10 +72,12 @@ export interface ReferenceDeliveryBlueprint extends FunctionalUnit {
 
     onBuildComplete: Maker<SetStatusOnBuildComplete>;
 
+    artifactFinder: Maker<HandleEvent<OnImageLinked.Subscription>>;
+
     /**
      * Initial deploy
      */
-    deploy1: Maker<HandleEvent<OnImageLinked.Subscription>>;
+    deploy1: Maker<HandleEvent<OnSuccessStatus.Subscription>>;
 
     notifyOnDeploy?: Maker<OnDeployStatus>;
 

--- a/src/sdm/ReferenceDeliveryBlueprint.ts
+++ b/src/sdm/ReferenceDeliveryBlueprint.ts
@@ -1,11 +1,14 @@
 import { HandleCommand, HandleEvent } from "@atomist/automation-client";
 import { Maker } from "@atomist/automation-client/util/constructionUtils";
+import { FindArtifactOnImageLinked } from "../handlers/events/delivery/build/BuildCompleteOnImageLinked";
 import { SetStatusOnBuildComplete } from "../handlers/events/delivery/build/SetStatusOnBuildComplete";
 import { OnDeployStatus } from "../handlers/events/delivery/deploy/OnDeployStatus";
 import { FailDownstreamPhasesOnPhaseFailure } from "../handlers/events/delivery/FailDownstreamPhasesOnPhaseFailure";
 import { OnSuperseded } from "../handlers/events/delivery/phase/OnSuperseded";
 import { SetSupersededStatus } from "../handlers/events/delivery/phase/SetSupersededStatus";
 import { SetupPhasesOnPush } from "../handlers/events/delivery/phase/SetupPhasesOnPush";
+import { ArtifactContext } from "../handlers/events/delivery/phases/gitHubContext";
+import { ContextToPlannedPhase } from "../handlers/events/delivery/phases/httpServicePhases";
 import { WithCodeOnPendingScanStatus } from "../handlers/events/delivery/review/WithCodeOnPendingScanStatus";
 import { OnVerifiedStatus } from "../handlers/events/delivery/verify/OnVerifiedStatus";
 import { VerifyOnEndpointStatus } from "../handlers/events/delivery/verify/VerifyOnEndpointStatus";
@@ -18,9 +21,6 @@ import {
     OnSupersededStatus,
 } from "../typings/types";
 import { FunctionalUnit } from "./FunctionalUnit";
-import { ContextToPlannedPhase } from "../handlers/events/delivery/phases/httpServicePhases";
-import { ArtifactContext } from "../handlers/events/delivery/phases/gitHubContext";
-import { FindArtifactOnImageLinked } from "../handlers/events/delivery/build/BuildCompleteOnImageLinked";
 
 /**
  * An environment to promote into. Normally there is only one, for production

--- a/src/software-delivery-machine/SpringK8sSoftwareDeliveryMachine.ts
+++ b/src/software-delivery-machine/SpringK8sSoftwareDeliveryMachine.ts
@@ -1,0 +1,108 @@
+import { HandleEvent, logger } from "@atomist/automation-client";
+import { Maker } from "@atomist/automation-client/util/constructionUtils";
+import { springBootTagger } from "@atomist/spring-automation/commands/tag/springTagger";
+import { FindArtifactOnImageLinked } from "../handlers/events/delivery/build/BuildCompleteOnImageLinked";
+import { SetupPhasesOnPush } from "../handlers/events/delivery/phase/SetupPhasesOnPush";
+import { Phases } from "../handlers/events/delivery/Phases";
+import { ArtifactContext, ScanContext } from "../handlers/events/delivery/phases/gitHubContext";
+import { ContextToPlannedPhase, HttpServicePhases } from "../handlers/events/delivery/phases/httpServicePhases";
+import { LibraryPhases } from "../handlers/events/delivery/phases/libraryPhases";
+import { checkstyleReviewer } from "../handlers/events/delivery/review/checkstyleReviewer";
+import { LookFor200OnEndpointRootGet } from "../handlers/events/delivery/verify/lookFor200OnEndpointRootGet";
+import { OnVerifiedStatus } from "../handlers/events/delivery/verify/OnVerifiedStatus";
+import { VerifyOnEndpointStatus } from "../handlers/events/delivery/verify/VerifyOnEndpointStatus";
+import { tagRepo } from "../handlers/events/repo/tagRepo";
+import { StatusSuccessHandler } from "../handlers/events/StatusSuccessHandler";
+import { AbstractSoftwareDeliveryMachine } from "../sdm/AbstractSoftwareDeliveryMachine";
+import { PromotedEnvironment } from "../sdm/ReferenceDeliveryBlueprint";
+import { OnAnySuccessStatus } from "../typings/types";
+import { CloudFoundryProductionDeployOnFingerprint, } from "./blueprint/deploy/cloudFoundryDeploy";
+import { DeployToProd } from "./blueprint/deploy/deployToProd";
+import { DescribeStagingAndProd } from "./blueprint/deploy/describeRunningServices";
+import { LocalMavenDeployOnImageLinked } from "./blueprint/deploy/mavenDeploy";
+import { OfferPromotion, offerPromotionCommand } from "./blueprint/deploy/offerPromotion";
+import { PostToDeploymentsChannel } from "./blueprint/deploy/postToDeploymentsChannel";
+import { diff1 } from "./blueprint/fingerprint/reactToFingerprintDiffs";
+import { PhaseSetup } from "./blueprint/phase/phaseManagement";
+import { suggestAddingCloudFoundryManifest } from "./blueprint/repo/suggestAddingCloudFoundryManifest";
+import { logReactor, logReview } from "./blueprint/review/scan";
+import { addCloudFoundryManifest } from "./commands/editors/addCloudFoundryManifest";
+import { springBootGenerator } from "./commands/generators/spring/springBootGenerator";
+import { mavenFingerprinter } from "./blueprint/fingerprint/maven/mavenFingerprinter";
+import { K8sBuildOnSuccessStatus } from "./blueprint/build/K8sBuildOnScanSuccess";
+import { K8sStagingDeployOnSuccessStatus, NoticeK8sDeployCompletion } from "./blueprint/deploy/k8sDeploy";
+
+const LocalMavenDeployer = LocalMavenDeployOnImageLinked;
+
+// CloudFoundryStagingDeployOnImageLinked
+
+export class SpringK8sSoftwareDeliveryMachine extends AbstractSoftwareDeliveryMachine {
+
+    protected scanContext = ScanContext;
+
+    public phaseSetup: Maker<SetupPhasesOnPush> = PhaseSetup;
+
+    public builder: Maker<StatusSuccessHandler> = K8sBuildOnSuccessStatus;
+
+    public artifactFinder = () => new FindArtifactOnImageLinked(ContextToPlannedPhase[ArtifactContext]);
+
+    public deploy1: Maker<HandleEvent<OnAnySuccessStatus.Subscription>> =
+        K8sStagingDeployOnSuccessStatus;
+
+    public verifyEndpoint: Maker<VerifyOnEndpointStatus> = LookFor200OnEndpointRootGet;
+
+    public onVerifiedStatus: Maker<OnVerifiedStatus> = OfferPromotion;
+
+    public promotedEnvironment: PromotedEnvironment = {
+
+        name: "production",
+
+        offerPromotionCommand,
+
+        promote: DeployToProd,
+
+        deploy: CloudFoundryProductionDeployOnFingerprint,
+    };
+
+    get possiblePhases(): Phases[] {
+        return [HttpServicePhases, LibraryPhases];
+    }
+
+    constructor() {
+        super();
+        this.addGenerators(() => springBootGenerator())
+            .addNewRepoWithCodeActions(
+                tagRepo(springBootTagger),
+                suggestAddingCloudFoundryManifest)
+            .addProjectReviewers(logReview)
+            .addSupportingEvents(() => NoticeK8sDeployCompletion);
+        const checkStylePath = process.env.CHECKSTYLE_PATH;
+        if (!!checkStylePath) {
+            this.addProjectReviewers(checkstyleReviewer(checkStylePath));
+        } else {
+            logger.warn("Skipping Checkstyle; to enable it, set CHECKSTYLE_PATH env variable to the location of a downloaded checkstyle jar");
+        }
+        this.addCodeReactions(logReactor)
+        // .addAutoEditors(
+        //     async p => {
+        //         try {
+        //             await p.findFile("thing");
+        //             return p;
+        //         } catch {
+        //             return p.addFile("thing", "1");
+        //         }
+        //     })
+            .addMultiFingerprinters(mavenFingerprinter)
+            .addFingerprintDifferenceHandlers(diff1)
+            .addDeploymentListeners(PostToDeploymentsChannel)
+            .addSupersededListeners(
+                id => {
+                    logger.info("Will undeploy application %j", id);
+                    return LocalMavenDeployer.deployer.undeploy(id);
+                })
+            .addSupportingCommands(
+                () => addCloudFoundryManifest,
+                DescribeStagingAndProd,
+            );
+    }
+}

--- a/src/software-delivery-machine/SpringPCFSoftwareDeliveryMachine.ts
+++ b/src/software-delivery-machine/SpringPCFSoftwareDeliveryMachine.ts
@@ -33,6 +33,7 @@ import { addCloudFoundryManifest } from "./commands/editors/addCloudFoundryManif
 import { springBootGenerator } from "./commands/generators/spring/springBootGenerator";
 import { mavenFingerprinter } from "./blueprint/fingerprint/maven/mavenFingerprinter";
 import { publishNewRepo } from "./blueprint/repo/publishNewRepo";
+import { EventWithCommand } from "../handlers/commands/RetryDeploy";
 
 const LocalMavenDeployer = LocalMavenDeployOnImageLinked;
 
@@ -46,7 +47,7 @@ export class SpringPCFSoftwareDeliveryMachine extends AbstractSoftwareDeliveryMa
 
     public artifactFinder = () => new FindArtifactOnImageLinked(ContextToPlannedPhase[ArtifactContext]);
 
-    public deploy1: Maker<HandleEvent<OnAnySuccessStatus.Subscription>> =
+    public deploy1: Maker<HandleEvent<OnAnySuccessStatus.Subscription> & EventWithCommand> =
         CloudFoundryStagingDeployOnSuccessStatus; // LocalMavenDeployer;
 
     public verifyEndpoint: Maker<VerifyOnEndpointStatus> = LookFor200OnEndpointRootGet;

--- a/src/software-delivery-machine/SpringPCFSoftwareDeliveryMachine.ts
+++ b/src/software-delivery-machine/SpringPCFSoftwareDeliveryMachine.ts
@@ -1,6 +1,7 @@
 import { HandleEvent, logger } from "@atomist/automation-client";
 import { Maker } from "@atomist/automation-client/util/constructionUtils";
 import { springBootTagger } from "@atomist/spring-automation/commands/tag/springTagger";
+import { FindArtifactOnImageLinked } from "../handlers/events/delivery/build/BuildCompleteOnImageLinked";
 import { SetupPhasesOnPush } from "../handlers/events/delivery/phase/SetupPhasesOnPush";
 import { Phases } from "../handlers/events/delivery/Phases";
 import { ArtifactContext, ScanContext } from "../handlers/events/delivery/phases/gitHubContext";
@@ -14,7 +15,7 @@ import { tagRepo } from "../handlers/events/repo/tagRepo";
 import { StatusSuccessHandler } from "../handlers/events/StatusSuccessHandler";
 import { AbstractSoftwareDeliveryMachine } from "../sdm/AbstractSoftwareDeliveryMachine";
 import { PromotedEnvironment } from "../sdm/ReferenceDeliveryBlueprint";
-import { OnImageLinked, OnSuccessStatus } from "../typings/types";
+import { OnAnySuccessStatus, OnImageLinked, OnSuccessStatus } from "../typings/types";
 import { LocalMavenBuildOnSuccessStatus } from "./blueprint/build/LocalMavenBuildOnScanSuccessStatus";
 import {
     CloudFoundryProductionDeployOnFingerprint, CloudFoundryStagingDeployOnSuccessStatus,
@@ -32,7 +33,6 @@ import { addCloudFoundryManifest } from "./commands/editors/addCloudFoundryManif
 import { springBootGenerator } from "./commands/generators/spring/springBootGenerator";
 import { mavenFingerprinter } from "./blueprint/fingerprint/maven/mavenFingerprinter";
 import { publishNewRepo } from "./blueprint/repo/publishNewRepo";
-import { FindArtifactOnImageLinked } from "../handlers/events/delivery/build/BuildCompleteOnImageLinked";
 
 const LocalMavenDeployer = LocalMavenDeployOnImageLinked;
 
@@ -46,7 +46,7 @@ export class SpringPCFSoftwareDeliveryMachine extends AbstractSoftwareDeliveryMa
 
     public artifactFinder = () => new FindArtifactOnImageLinked(ContextToPlannedPhase[ArtifactContext]);
 
-    public deploy1: Maker<HandleEvent<OnSuccessStatus.Subscription>> =
+    public deploy1: Maker<HandleEvent<OnAnySuccessStatus.Subscription>> =
         CloudFoundryStagingDeployOnSuccessStatus; // LocalMavenDeployer;
 
     public verifyEndpoint: Maker<VerifyOnEndpointStatus> = LookFor200OnEndpointRootGet;

--- a/src/software-delivery-machine/blueprint/build/K8sBuildOnScanSuccess.ts
+++ b/src/software-delivery-machine/blueprint/build/K8sBuildOnScanSuccess.ts
@@ -1,0 +1,13 @@
+import { BuildOnScanSuccessStatus } from "../../../handlers/events/delivery/build/BuildOnScanSuccessStatus";
+import { MavenBuilder } from "../../../handlers/events/delivery/build/local/maven/MavenBuilder";
+import { createLinkableProgressLog } from "../../../handlers/events/delivery/log/NaiveLinkablePersistentProgressLog";
+import { BuildContext } from "../../../handlers/events/delivery/phases/gitHubContext";
+import { HttpServicePhases } from "../../../handlers/events/delivery/phases/httpServicePhases";
+import { artifactStore } from "../artifactStore";
+import { K8sAutomationBuilder } from "../../../handlers/events/delivery/build/k8s/K8AutomationBuilder";
+
+export const K8sBuildOnSuccessStatus = () =>
+    new BuildOnScanSuccessStatus(
+        HttpServicePhases,
+        BuildContext,
+        new K8sAutomationBuilder());

--- a/src/software-delivery-machine/blueprint/build/LocalMavenBuildOnScanSuccessStatus.ts
+++ b/src/software-delivery-machine/blueprint/build/LocalMavenBuildOnScanSuccessStatus.ts
@@ -1,12 +1,12 @@
 import { BuildOnScanSuccessStatus } from "../../../handlers/events/delivery/build/BuildOnScanSuccessStatus";
 import { MavenBuilder } from "../../../handlers/events/delivery/build/local/maven/MavenBuilder";
 import { createLinkableProgressLog } from "../../../handlers/events/delivery/log/NaiveLinkablePersistentProgressLog";
-import { BuiltContext } from "../../../handlers/events/delivery/phases/gitHubContext";
+import { BuildContext } from "../../../handlers/events/delivery/phases/gitHubContext";
 import { HttpServicePhases } from "../../../handlers/events/delivery/phases/httpServicePhases";
 import { artifactStore } from "../artifactStore";
 
-export const LocalMavenBuildOnSucessStatus = () =>
+export const LocalMavenBuildOnSuccessStatus = () =>
     new BuildOnScanSuccessStatus(
         HttpServicePhases,
-        BuiltContext,
+        BuildContext,
         new MavenBuilder(artifactStore, createLinkableProgressLog));

--- a/src/software-delivery-machine/blueprint/deploy/cloudFoundryDeploy.ts
+++ b/src/software-delivery-machine/blueprint/deploy/cloudFoundryDeploy.ts
@@ -15,7 +15,7 @@
  */
 
 import { DeployFromLocalOnFingerprint } from "../../../handlers/events/delivery/deploy/DeployFromLocalOnFingerprint";
-import { DeployFromLocalOnSuccessStatus } from "../../../handlers/events/delivery/deploy/DeployFromLocalOnImageLinked";
+import { DeployFromLocalOnSuccessStatus } from "../../../handlers/events/delivery/deploy/DeployFromLocalOnSuccessStatus";
 import {
     CloudFoundryInfo,
     EnvironmentCloudFoundryTarget,

--- a/src/software-delivery-machine/blueprint/deploy/cloudFoundryDeploy.ts
+++ b/src/software-delivery-machine/blueprint/deploy/cloudFoundryDeploy.ts
@@ -22,7 +22,7 @@ import {
 } from "../../../handlers/events/delivery/deploy/pcf/CloudFoundryTarget";
 import { CommandLineCloudFoundryDeployer } from "../../../handlers/events/delivery/deploy/pcf/CommandLineCloudFoundryDeployer";
 import {
-    CloudFoundryStagingDeploymentContext,
+    StagingDeploymentContext,
     ContextToPlannedPhase,
     HttpServicePhases,
     StagingEndpointContext,
@@ -43,7 +43,7 @@ export const Deployer = new CommandLineCloudFoundryDeployer();
 export const CloudFoundryStagingDeployOnSuccessStatus = () =>
     new DeployFromLocalOnSuccessStatus(
         HttpServicePhases,
-        ContextToPlannedPhase[CloudFoundryStagingDeploymentContext],
+        ContextToPlannedPhase[StagingDeploymentContext],
         ContextToPlannedPhase[StagingEndpointContext],
         artifactStore,
         Deployer,

--- a/src/software-delivery-machine/blueprint/deploy/cloudFoundryDeploy.ts
+++ b/src/software-delivery-machine/blueprint/deploy/cloudFoundryDeploy.ts
@@ -15,7 +15,7 @@
  */
 
 import { DeployFromLocalOnFingerprint } from "../../../handlers/events/delivery/deploy/DeployFromLocalOnFingerprint";
-import { DeployFromLocalOnImageLinked } from "../../../handlers/events/delivery/deploy/DeployFromLocalOnImageLinked";
+import { DeployFromLocalOnSuccessStatus } from "../../../handlers/events/delivery/deploy/DeployFromLocalOnImageLinked";
 import {
     CloudFoundryInfo,
     EnvironmentCloudFoundryTarget,
@@ -40,8 +40,8 @@ export const Deployer = new CommandLineCloudFoundryDeployer();
  * Deploy everything to the same Cloud Foundry space
  * @type {DeployFromLocalOnImageLinked<CloudFoundryInfo>}
  */
-export const CloudFoundryStagingDeployOnImageLinked = () =>
-    new DeployFromLocalOnImageLinked(
+export const CloudFoundryStagingDeployOnSuccessStatus = () =>
+    new DeployFromLocalOnSuccessStatus(
         HttpServicePhases,
         ContextToPlannedPhase[CloudFoundryStagingDeploymentContext],
         ContextToPlannedPhase[StagingEndpointContext],

--- a/src/software-delivery-machine/blueprint/deploy/deployToProd.ts
+++ b/src/software-delivery-machine/blueprint/deploy/deployToProd.ts
@@ -14,7 +14,7 @@ import { addressSlackUsers } from "@atomist/automation-client/spi/message/Messag
 import * as slack from "@atomist/slack-messages/SlackMessages";
 import { sendFingerprint } from "../../../handlers/commands/editors/toclient/fingerprints";
 import { listStatuses, Status } from "../../../handlers/commands/editors/toclient/ghub";
-import { BuiltContext } from "../../../handlers/events/delivery/phases/gitHubContext";
+import { BuildContext } from "../../../handlers/events/delivery/phases/gitHubContext";
 import { ProductionDeployPhases } from "../../../handlers/events/delivery/phases/productionDeployPhases";
 
 @CommandHandler("Promote to production", "promote to production")
@@ -98,6 +98,6 @@ function tryAgainMessage(params: DeployToProd, message: string) {
 function findArtifactStatus(id: GitHubRepoRef, token: string): Promise<Status> {
     return listStatuses(token, id)
         .then(statuses => {
-            return statuses.find(s => s.context === BuiltContext);
+            return statuses.find(s => s.context === BuildContext);
         });
 }

--- a/src/software-delivery-machine/blueprint/deploy/k8sDeploy.ts
+++ b/src/software-delivery-machine/blueprint/deploy/k8sDeploy.ts
@@ -1,0 +1,15 @@
+import {
+    ContextToPlannedPhase, HttpServicePhases, StagingDeploymentContext,
+    StagingEndpointContext
+} from "../../../handlers/events/delivery/phases/httpServicePhases";
+import { RequestK8sDeployOnSuccessStatus } from "../../../handlers/events/delivery/deploy/k8s/RequestDeployOnSuccessStatus";
+import { NoticeK8sDeployCompletionOnStatus } from "../../../handlers/events/delivery/deploy/k8s/NoticeK8sDeployCompletion";
+
+export const K8sStagingDeployOnSuccessStatus = () =>
+    new RequestK8sDeployOnSuccessStatus(
+        HttpServicePhases,
+        ContextToPlannedPhase[StagingEndpointContext]);
+
+export const NoticeK8sDeployCompletion = new NoticeK8sDeployCompletionOnStatus(
+    ContextToPlannedPhase[StagingDeploymentContext],
+    ContextToPlannedPhase[StagingEndpointContext])

--- a/src/software-delivery-machine/blueprint/deploy/mavenDeploy.ts
+++ b/src/software-delivery-machine/blueprint/deploy/mavenDeploy.ts
@@ -19,7 +19,7 @@ import { TargetInfo } from "../../../handlers/events/delivery/deploy/Deployment"
 import { executableJarDeployer } from "../../../handlers/events/delivery/deploy/local/maven/executableJarDeployer";
 import { CloudFoundryInfo } from "../../../handlers/events/delivery/deploy/pcf/CloudFoundryTarget";
 import {
-    CloudFoundryStagingDeploymentContext,
+    StagingDeploymentContext,
     ContextToPlannedPhase,
     HttpServicePhases,
     StagingEndpointContext,
@@ -33,7 +33,7 @@ import { artifactStore } from "../artifactStore";
 export const LocalMavenDeployOnImageLinked: DeployFromLocalOnSuccessStatus<TargetInfo> =
     new DeployFromLocalOnSuccessStatus<TargetInfo>(
         HttpServicePhases,
-        ContextToPlannedPhase[CloudFoundryStagingDeploymentContext],
+        ContextToPlannedPhase[StagingDeploymentContext],
         ContextToPlannedPhase[StagingEndpointContext],
         artifactStore,
         executableJarDeployer(),

--- a/src/software-delivery-machine/blueprint/deploy/mavenDeploy.ts
+++ b/src/software-delivery-machine/blueprint/deploy/mavenDeploy.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { DeployFromLocalOnImageLinked } from "../../../handlers/events/delivery/deploy/DeployFromLocalOnImageLinked";
 import { TargetInfo } from "../../../handlers/events/delivery/deploy/Deployment";
 import { executableJarDeployer } from "../../../handlers/events/delivery/deploy/local/maven/executableJarDeployer";
 import { CloudFoundryInfo } from "../../../handlers/events/delivery/deploy/pcf/CloudFoundryTarget";
@@ -25,13 +24,14 @@ import {
     StagingEndpointContext,
 } from "../../../handlers/events/delivery/phases/httpServicePhases";
 import { artifactStore } from "../artifactStore";
+import { DeployFromLocalOnSuccessStatus } from "../../../handlers/events/delivery/deploy/DeployFromLocalOnImageLinked";
 
 /**
  * Deploy everything to the same Cloud Foundry space
  * @type {DeployFromLocalOnImageLinked<CloudFoundryInfo>}
  */
-export const LocalMavenDeployOnImageLinked: DeployFromLocalOnImageLinked<TargetInfo> =
-    new DeployFromLocalOnImageLinked(
+export const LocalMavenDeployOnImageLinked: DeployFromLocalOnSuccessStatus<TargetInfo> =
+    new DeployFromLocalOnSuccessStatus<TargetInfo>(
         HttpServicePhases,
         ContextToPlannedPhase[CloudFoundryStagingDeploymentContext],
         ContextToPlannedPhase[StagingEndpointContext],

--- a/src/software-delivery-machine/blueprint/deploy/mavenDeploy.ts
+++ b/src/software-delivery-machine/blueprint/deploy/mavenDeploy.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { DeployFromLocalOnSuccessStatus } from "../../../handlers/events/delivery/deploy/DeployFromLocalOnImageLinked";
 import { TargetInfo } from "../../../handlers/events/delivery/deploy/Deployment";
 import { executableJarDeployer } from "../../../handlers/events/delivery/deploy/local/maven/executableJarDeployer";
 import { CloudFoundryInfo } from "../../../handlers/events/delivery/deploy/pcf/CloudFoundryTarget";
@@ -24,7 +25,6 @@ import {
     StagingEndpointContext,
 } from "../../../handlers/events/delivery/phases/httpServicePhases";
 import { artifactStore } from "../artifactStore";
-import { DeployFromLocalOnSuccessStatus } from "../../../handlers/events/delivery/deploy/DeployFromLocalOnImageLinked";
 
 /**
  * Deploy everything to the same Cloud Foundry space

--- a/src/software-delivery-machine/blueprint/deploy/mavenDeploy.ts
+++ b/src/software-delivery-machine/blueprint/deploy/mavenDeploy.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { DeployFromLocalOnSuccessStatus } from "../../../handlers/events/delivery/deploy/DeployFromLocalOnImageLinked";
+import { DeployFromLocalOnSuccessStatus } from "../../../handlers/events/delivery/deploy/DeployFromLocalOnSuccessStatus";
 import { TargetInfo } from "../../../handlers/events/delivery/deploy/Deployment";
 import { executableJarDeployer } from "../../../handlers/events/delivery/deploy/local/maven/executableJarDeployer";
 import { CloudFoundryInfo } from "../../../handlers/events/delivery/deploy/pcf/CloudFoundryTarget";

--- a/src/software-delivery-machine/blueprint/deploy/offerPromotion.ts
+++ b/src/software-delivery-machine/blueprint/deploy/offerPromotion.ts
@@ -15,10 +15,10 @@ import { RemoteRepoRef } from "@atomist/automation-client/operations/common/Repo
 import { addressSlackChannels, buttonForCommand } from "@atomist/automation-client/spi/message/MessageClient";
 import { Maker } from "@atomist/automation-client/util/constructionUtils";
 import * as slack from "@atomist/slack-messages/SlackMessages";
+import {tipOfDefaultBranch} from "../../../handlers/commands/editors/toclient/ghub";
 import { runningAttachment } from "../../../handlers/commands/reportRunning";
 import { ProductionMauve } from "../../../handlers/events/delivery/phases/productionDeployPhases";
 import { OnVerifiedStatus, StatusInfo } from "../../../handlers/events/delivery/verify/OnVerifiedStatus";
-import {tipOfDefaultBranch} from "../../../handlers/commands/editors/toclient/ghub";
 
 /**
  * Display a button suggesting promotion to production

--- a/test/handlers/events/delivery/PhasesTest.ts
+++ b/test/handlers/events/delivery/PhasesTest.ts
@@ -23,7 +23,7 @@ describe("Phase handling", () => {
        assert(contextIsAfter(BuildContext, CloudFoundryStagingDeploymentContext));
    });
 
-    it("says prod endpoint is after prod ", () => {
+   it("says prod endpoint is after prod ", () => {
         assert(contextIsAfter(ProductionDeploymentContext, ProductionEndpointContext));
     });
 

--- a/test/handlers/events/delivery/PhasesTest.ts
+++ b/test/handlers/events/delivery/PhasesTest.ts
@@ -1,6 +1,6 @@
 import "mocha";
 import * as assert from "power-assert";
-import {BaseContext, BuiltContext, contextIsAfter, ScanContext, splitContext} from "../../../../src/handlers/events/delivery/phases/gitHubContext";
+import {BaseContext, BuildContext, contextIsAfter, ScanContext, splitContext} from "../../../../src/handlers/events/delivery/phases/gitHubContext";
 import {CloudFoundryStagingDeploymentContext, StagingEndpointContext} from "../../../../src/handlers/events/delivery/phases/httpServicePhases";
 import {ProductionDeploymentContext, ProductionEndpointContext} from "../../../../src/handlers/events/delivery/phases/productionDeployPhases";
 
@@ -20,7 +20,7 @@ describe("Phase handling", () => {
    });
 
    it("says deploy is after build", () => {
-       assert(contextIsAfter(BuiltContext, CloudFoundryStagingDeploymentContext));
+       assert(contextIsAfter(BuildContext, CloudFoundryStagingDeploymentContext));
    });
 
     it("says prod endpoint is after prod ", () => {

--- a/test/handlers/events/delivery/PhasesTest.ts
+++ b/test/handlers/events/delivery/PhasesTest.ts
@@ -1,7 +1,7 @@
 import "mocha";
 import * as assert from "power-assert";
 import {BaseContext, BuildContext, contextIsAfter, ScanContext, splitContext} from "../../../../src/handlers/events/delivery/phases/gitHubContext";
-import {CloudFoundryStagingDeploymentContext, StagingEndpointContext} from "../../../../src/handlers/events/delivery/phases/httpServicePhases";
+import {StagingDeploymentContext, StagingEndpointContext} from "../../../../src/handlers/events/delivery/phases/httpServicePhases";
 import {ProductionDeploymentContext, ProductionEndpointContext} from "../../../../src/handlers/events/delivery/phases/productionDeployPhases";
 
 describe("Phase handling", () => {
@@ -16,11 +16,11 @@ describe("Phase handling", () => {
    });
 
    it("says endpoint is after deploy", () => {
-       assert(contextIsAfter(CloudFoundryStagingDeploymentContext, StagingEndpointContext));
+       assert(contextIsAfter(StagingDeploymentContext, StagingEndpointContext));
    });
 
    it("says deploy is after build", () => {
-       assert(contextIsAfter(BuildContext, CloudFoundryStagingDeploymentContext));
+       assert(contextIsAfter(BuildContext, StagingDeploymentContext));
    });
 
    it("says prod endpoint is after prod ", () => {

--- a/test/handlers/events/delivery/artifact/gitHubReleaseArtifactStoreTest.ts
+++ b/test/handlers/events/delivery/artifact/gitHubReleaseArtifactStoreTest.ts
@@ -1,15 +1,14 @@
 import "mocha";
 
+import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
+import * as fs from "fs";
 import * as assert from "power-assert";
 import {
     GitHubReleaseArtifactStore,
 } from "../../../../../src/handlers/events/delivery/artifact/github/GitHubReleaseArtifactStore";
-import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
-import * as fs from "fs";
 
-import * as p from "path";
 import { runCommand } from "@atomist/automation-client/action/cli/commandLine";
-
+import * as p from "path";
 
 const asset = "https://github.com/spring-team/fintan/releases/download/0.1.0-SNAPSHOT454/fintan-0.1.0-SNAPSHOT.jar";
 


### PR DESCRIPTION
This separates build from artifact status.

It includes a trigger-er for the k8s build which, if we switch to it, should work.
The deploy part isn't done yet

but this should be integrable, we should fold it in