### PR TITLE
let build finish before returning

### DIFF
--- a/src/handlers/events/delivery/Phases.ts
+++ b/src/handlers/events/delivery/Phases.ts
@@ -121,8 +121,12 @@ export function nothingFailed(status: GitHubStatusAndFriends): boolean {
 }
 
 export function previousPhaseSucceeded(expectedPhases: Phases, currentPhase: GitHubStatusContext, status: GitHubStatusAndFriends): boolean {
-    if (status.state !== "success" || status.targetUrl.endsWith(ApprovalGateParam)) {
+    if (status.state !== "success" ) {
         logger.info(`********* Previous state ${status.context} wasn't success, but [${status.state}]`);
+        return false;
+    }
+    if(status.targetUrl.endsWith(ApprovalGateParam)) {
+        logger.info(`Approval gate detected in ${status.context}`)
         return false;
     }
 

--- a/src/handlers/events/delivery/build/BuildOnScanSuccessStatus.ts
+++ b/src/handlers/events/delivery/build/BuildOnScanSuccessStatus.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { GraphQL, HandlerResult, Secret, Secrets, Success } from "@atomist/automation-client";
+import { GraphQL, HandlerResult, logger, Secret, Secrets, Success } from "@atomist/automation-client";
 import { EventFired, EventHandler, HandlerContext } from "@atomist/automation-client/Handlers";
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import { OnAnySuccessStatus } from "../../../../typings/types";
@@ -58,10 +58,11 @@ export class BuildOnScanSuccessStatus implements StatusSuccessHandler {
             return Promise.resolve(Success);
         }
 
+        logger.info(`Running build, triggered by ${status.state} on ${status.context}: ${status.description}`)
+
         const id = new GitHubRepoRef(commit.repo.owner, commit.repo.name, commit.sha);
         const creds = {token: params.githubToken};
 
-        await params.builder.initiateBuild(creds, id, addressChannelsFor(commit.repo, ctx), team);
-        return Success;
+        return params.builder.initiateBuild(creds, id, addressChannelsFor(commit.repo, ctx), team);
     }
 }

--- a/src/handlers/events/delivery/build/local/maven/MavenBuilder.ts
+++ b/src/handlers/events/delivery/build/local/maven/MavenBuilder.ts
@@ -24,36 +24,36 @@ export class MavenBuilder extends LocalBuilder implements LogInterpretation {
         super(artifactStore, logFactory);
     }
 
-    protected startBuild(creds: ProjectOperationCredentials,
-                         id: RemoteRepoRef,
-                         team: string, log: LinkablePersistentProgressLog): Promise<LocalBuildInProgress> {
-        return GitCommandGitProject.cloned(creds, id)
-            .then(p => {
-                console.log("Checked out project ok");
-                // Find the artifact info from Maven
-                return p.findFile("pom.xml")
-                    .then(pom => pom.getContent()
-                        .then(content => identification(content)))
-                    .then(va => ({...va, name: va.artifact, id}))
-                    .then(appId => {
-                        const childProcess = spawn("mvn", [
-                            "package",
-                            "-DskipTests",
-                        ], {
-                            cwd: p.baseDir,
-                        });
-                        const rb = new UpdatingBuild(id, childProcess, team, log.url);
-                        childProcess.stdout.on("data", data => {
-                            log.write(data.toString());
-                        });
-                        childProcess.addListener("exit", (code, signal) => {
-                            rb.ai = appId;
-                            // rb._deploymentUnitStream = fs.createReadStream(`${p.baseDir}/target/losgatos1-0.1.0-SNAPSHOT.jar`);
-                            rb.deploymentUnitFile = `${p.baseDir}/target/${appId.name}-${appId.version}.jar`;
-                        });
-                        return rb;
-                    });
+    protected async startBuild(creds: ProjectOperationCredentials,
+                               id: RemoteRepoRef,
+                               team: string, log: LinkablePersistentProgressLog): Promise<LocalBuildInProgress> {
+        const p = await GitCommandGitProject.cloned(creds, id)
+        // Find the artifact info from Maven
+        const pom = await p.findFile("pom.xml")
+        const content = await pom.getContent()
+        const va = await identification(content)
+        const appId = {...va, name: va.artifact, id};
+        const childProcess = spawn("mvn", [
+            "package",
+            "-DskipTests",
+        ], {
+            cwd: p.baseDir,
+        });
+        const buildResult = new Promise<{ error: boolean, code: number }>((resolve, reject) => {
+            childProcess.stdout.on("data", data => {
+                log.write(data.toString());
             });
+            childProcess.addListener("exit", (code, signal) => {
+                resolve({error: false, code});
+            });
+            childProcess.addListener("error", (code, signal) => {
+                resolve({error: true, code});
+            });
+        });
+        const rb = new UpdatingBuild(id, buildResult, team, log.url);
+        rb.ai = appId;
+        rb.deploymentUnitFile = `${p.baseDir}/target/${appId.name}-${appId.version}.jar`;
+        return rb;
     }
 
     public logInterpreter(log: string): InterpretedLog | undefined {
@@ -72,14 +72,12 @@ export class MavenBuilder extends LocalBuilder implements LogInterpretation {
 class UpdatingBuild implements LocalBuildInProgress {
 
     constructor(public repoRef: RemoteRepoRef,
-                public stream: ChildProcess,
+                public buildResult: Promise<{error: boolean, code: number}>,
                 public team: string,
                 public url: string) {
     }
 
     public ai: AppInfo;
-
-    public deploymentUnitStream: Readable;
 
     public deploymentUnitFile: string;
 

--- a/src/handlers/events/delivery/build/local/maven/MavenBuilder.ts
+++ b/src/handlers/events/delivery/build/local/maven/MavenBuilder.ts
@@ -29,6 +29,7 @@ export class MavenBuilder extends LocalBuilder implements LogInterpretation {
                          team: string, log: LinkablePersistentProgressLog): Promise<LocalBuildInProgress> {
         return GitCommandGitProject.cloned(creds, id)
             .then(p => {
+                console.log("Checked out project ok");
                 // Find the artifact info from Maven
                 return p.findFile("pom.xml")
                     .then(pom => pom.getContent()

--- a/src/software-delivery-machine/SpringPCFSoftwareDeliveryMachine.ts
+++ b/src/software-delivery-machine/SpringPCFSoftwareDeliveryMachine.ts
@@ -15,7 +15,7 @@ import { StatusSuccessHandler } from "../handlers/events/StatusSuccessHandler";
 import { AbstractSoftwareDeliveryMachine } from "../sdm/AbstractSoftwareDeliveryMachine";
 import { PromotedEnvironment } from "../sdm/ReferenceDeliveryBlueprint";
 import { OnImageLinked } from "../typings/types";
-import { LocalMavenBuildOnSucessStatus } from "./blueprint/build/LocalMavenBuildOnScanSuccessStatus";
+import { LocalMavenBuildOnSuccessStatus } from "./blueprint/build/LocalMavenBuildOnScanSuccessStatus";
 import {
     CloudFoundryProductionDeployOnFingerprint,
     CloudFoundryStagingDeployOnImageLinked,
@@ -42,10 +42,10 @@ export class SpringPCFSoftwareDeliveryMachine extends AbstractSoftwareDeliveryMa
 
     public phaseSetup: Maker<SetupPhasesOnPush> = PhaseSetup;
 
-    public builder: Maker<StatusSuccessHandler> = LocalMavenBuildOnSucessStatus;
+    public builder: Maker<StatusSuccessHandler> = LocalMavenBuildOnSuccessStatus;
 
     public deploy1: Maker<HandleEvent<OnImageLinked.Subscription>> =
-        CloudFoundryStagingDeployOnImageLinked; // LocalMavenDeployer;
+        () => LocalMavenDeployer; //  CloudFoundryStagingDeployOnImageLinked; // () => LocalMavenDeployer;
 
     public verifyEndpoint: Maker<VerifyOnEndpointStatus> = LookFor200OnEndpointRootGet;
 

--- a/src/software-delivery-machine/SpringPCFSoftwareDeliveryMachine.ts
+++ b/src/software-delivery-machine/SpringPCFSoftwareDeliveryMachine.ts
@@ -45,7 +45,7 @@ export class SpringPCFSoftwareDeliveryMachine extends AbstractSoftwareDeliveryMa
     public builder: Maker<StatusSuccessHandler> = LocalMavenBuildOnSuccessStatus;
 
     public deploy1: Maker<HandleEvent<OnImageLinked.Subscription>> =
-        () => LocalMavenDeployer; //  CloudFoundryStagingDeployOnImageLinked; // () => LocalMavenDeployer;
+       CloudFoundryStagingDeployOnImageLinked; // () => LocalMavenDeployer;
 
     public verifyEndpoint: Maker<VerifyOnEndpointStatus> = LookFor200OnEndpointRootGet;
 

--- a/src/software-delivery-machine/blueprint/build/LocalMavenBuildOnScanSuccessStatus.ts
+++ b/src/software-delivery-machine/blueprint/build/LocalMavenBuildOnScanSuccessStatus.ts
@@ -5,7 +5,7 @@ import { BuiltContext } from "../../../handlers/events/delivery/phases/gitHubCon
 import { HttpServicePhases } from "../../../handlers/events/delivery/phases/httpServicePhases";
 import { artifactStore } from "../artifactStore";
 
-export const LocalMavenBuildOnSucessStatus = () =>
+export const LocalMavenBuildOnSuccessStatus = () =>
     new BuildOnScanSuccessStatus(
         HttpServicePhases,
         BuiltContext,


### PR DESCRIPTION
This way the logs for the build appear with their correlation ID.
Also there is not a dependency on ordering of the "exit" handlers on a childProcess.
It's still a bit weird. It returns a promise (of a running build) containing a promise (of a completed build). This is OK.

please squash