### PR TITLE
Make one FailDownstream work for all

### DIFF
--- a/src/blueprint/SoftwareDeliveryMachine.ts
+++ b/src/blueprint/SoftwareDeliveryMachine.ts
@@ -139,7 +139,7 @@ export class SoftwareDeliveryMachine implements NewRepoHandling, ReferenceDelive
     }
 
     private get phaseCleanup(): Array<Maker<FailDownstreamPhasesOnPhaseFailure>> {
-        return this.possiblePhases.map(phases => () => new FailDownstreamPhasesOnPhaseFailure(phases));
+        return [() => new FailDownstreamPhasesOnPhaseFailure()];
     }
 
     private get possiblePhases(): Phases[] {

--- a/src/common/phases/Phases.ts
+++ b/src/common/phases/Phases.ts
@@ -55,34 +55,6 @@ export class Phases {
         }
     }
 
-    /**
-     * Set all downstream phase to failure status given a specific failed phase.
-     *
-     * The phases are associated by the atomist-sdm/${env}/ prefix in their context.
-     * This method's only dependency on the enclosing object is for selecting
-     * nicer names for the phases.
-     *
-     * @param {string} failedContext
-     * @param {GitHubRepoRef} id
-     * @param {ProjectOperationCredentials} creds
-     * @return {Promise<any>}
-     */
-    public gameOver(failedContext: GitHubStatusContext, currentlyPending: GitHubStatusContext[],
-                    id: GitHubRepoRef, creds: ProjectOperationCredentials): Promise<any> {
-        if (!this.phases.includes(failedContext)) {
-            // Don't fail all our outstanding phases because someone else failed an unrelated phase
-            return Promise.resolve();
-        }
-        const failedPhase: PlannedPhase = this.contextToPlannedPhase(this, failedContext);
-        const failedPhaseName = failedPhase.name;
-        const phasesToReset = currentlyPending
-            .filter(pendingContext => contextIsAfter(failedContext, pendingContext))
-            .map(p => this.contextToPlannedPhase(this, p));
-        return Promise.all(phasesToReset.map(
-            p => setStatus(id, p.context, "failure", creds,
-                `Skipping ${p.name} because ${failedPhaseName} failed`)));
-    }
-
 }
 
 function setStatus(id: GitHubRepoRef, context: GitHubStatusContext,

--- a/src/handlers/events/delivery/FailDownstreamPhasesOnPhaseFailure.ts
+++ b/src/handlers/events/delivery/FailDownstreamPhasesOnPhaseFailure.ts
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-import { GraphQL, HandlerResult, logger, Secret, Secrets, Success } from "@atomist/automation-client";
-import { EventFired, EventHandler, HandleEvent, HandlerContext } from "@atomist/automation-client/Handlers";
-import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
-import { Phases } from "../../../common/phases/Phases";
-import { OnFailureStatus, OnSuccessStatus } from "../../../typings/types";
+import {GraphQL, HandlerResult, logger, Secret, Secrets, Success} from "@atomist/automation-client";
+import {EventFired, EventHandler, HandleEvent, HandlerContext} from "@atomist/automation-client/Handlers";
+import {GitHubRepoRef} from "@atomist/automation-client/operations/common/GitHubRepoRef";
+import {Phases, PlannedPhase} from "../../../common/phases/Phases";
+import {OnFailureStatus, OnSuccessStatus} from "../../../typings/types";
 import Status = OnSuccessStatus.Status;
+import {BaseContext, contextIsAfter, GitHubStatusContext, splitContext} from "../../../common/phases/gitHubContext";
+import {ProjectOperationCredentials, TokenCredentials} from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
+import {createStatus, State} from "../../../util/github/ghub";
+import {contextToPlannedPhase, ContextToPlannedPhase} from "./phases/httpServicePhases";
 
 /**
  * Respond to a failure status by failing downstream phases
@@ -31,9 +35,6 @@ export class FailDownstreamPhasesOnPhaseFailure implements HandleEvent<OnFailure
     @Secret(Secrets.OrgToken)
     private githubToken: string;
 
-    constructor(private phases: Phases) {
-    }
-
     public handle(event: EventFired<OnFailureStatus.Subscription>, ctx: HandlerContext, params: this): Promise<HandlerResult> {
         const status: Status = event.data.Status[0];
         const commit = status.commit;
@@ -43,15 +44,60 @@ export class FailDownstreamPhasesOnPhaseFailure implements HandleEvent<OnFailure
             return Promise.resolve(Success);
         }
 
+        if (status.description.startsWith("Skipping ")) {
+            logger.debug("not relevant, because I set this status to failure in an earlier invocation of myself.");
+            logger.debug(`context: ${status.context} description: ${status.description}`);
+            return Promise.resolve(Success);
+        }
+
         const currentlyPending = status.commit.statuses.filter(s => s.state === "pending");
 
         const id = new GitHubRepoRef(commit.repo.owner, commit.repo.name, commit.sha);
 
-        return params.phases.gameOver(
+        return gameOver(
             status.context,
             currentlyPending.map(s => s.context),
             id,
             {token: params.githubToken})
             .then(() => Success);
     }
+}
+
+/**
+ * Set all downstream phase to failure status given a specific failed phase.
+ *
+ * The phases are associated by the atomist-sdm/${env}/ prefix in their context.
+ *
+ */
+function gameOver(failedContext: GitHubStatusContext, currentlyPending: GitHubStatusContext[],
+                  id: GitHubRepoRef, creds: ProjectOperationCredentials): Promise<any> {
+
+    const interpretedContext = splitContext(failedContext);
+
+    if (!interpretedContext) {
+        // this is not our status
+        logger.info("not relevant: " + failedContext);
+        return Promise.resolve();
+    }
+
+    const failedPhase: PlannedPhase = contextToPlannedPhase(failedContext);
+
+    const phasesToReset = currentlyPending
+        .filter(pendingContext => contextIsAfter(failedContext, pendingContext))
+        .map(p => contextToPlannedPhase(p));
+    return Promise.all(phasesToReset.map(
+        p => setStatus(id, p.context, "failure", creds,
+            `Skipping ${p.name} because ${failedPhase.name} failed`)));
+}
+
+function setStatus(id: GitHubRepoRef, context: GitHubStatusContext,
+                   state: State,
+                   creds: ProjectOperationCredentials,
+                   description: string = context): Promise<any> {
+    logger.debug("Setting pending status " + context + " to failure");
+    return createStatus((creds as TokenCredentials).token, id, {
+        state,
+        context,
+        description,
+    });
 }

--- a/src/handlers/events/delivery/phases/httpServicePhases.ts
+++ b/src/handlers/events/delivery/phases/httpServicePhases.ts
@@ -1,4 +1,7 @@
-import { ArtifactContext, BaseContext, BuildContext, ScanContext, StagingEnvironment } from "../../../../common/phases/gitHubContext";
+import {
+    ArtifactContext, BaseContext, BuildContext, GitHubStatusContext, ScanContext, splitContext,
+    StagingEnvironment
+} from "../../../../common/phases/gitHubContext";
 import { Phases, PlannedPhase } from "../../../../common/phases/Phases";
 
 export const StagingDeploymentContext = BaseContext + StagingEnvironment + "3-deploy";
@@ -15,6 +18,19 @@ ContextToPlannedPhase[StagingDeploymentContext] = {
 };
 ContextToPlannedPhase[StagingEndpointContext] = {context: StagingEndpointContext, name: "find endpoint in Test"};
 ContextToPlannedPhase[StagingVerifiedContext] = {context: StagingVerifiedContext, name: "verify endpoint in Test"};
+
+export function contextToPlannedPhase(ghsc: GitHubStatusContext): PlannedPhase {
+    return ContextToPlannedPhase[ghsc] ||
+        defaultPhaseDefinition(ghsc)
+}
+
+function defaultPhaseDefinition(ghsc: GitHubStatusContext): PlannedPhase {
+    const interpreted = splitContext(ghsc);
+    return {
+        context: ghsc,
+        name: interpreted.name
+    }
+}
 
 /**
  * Phases for an Http service


### PR DESCRIPTION
This gets the phases off the commit, then takes all later ones (by convention in context) that are pending and sets them to failed.