### PR TITLE
retry verify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomist/github-sdm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomist/github-sdm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "GitHub Software Delivery Machine",
   "author": "Atomist",
   "license": "Apache-2.0",

--- a/src/common/slack/addressChannels.ts
+++ b/src/common/slack/addressChannels.ts
@@ -18,7 +18,7 @@ export interface HasChannels {
 
 export function addressChannelsFor(hasChannels: HasChannels, ctx: HandlerContext): AddressChannels {
     if (!!hasChannels.channels) {
-        return (msg, opts) => ctx.messageClient.send(msg, messageDestinations(hasChannels, ctx), opts);
+        return addressDestination(messageDestinations(hasChannels, ctx), ctx);
     } else {
         return () => Promise.resolve();
     }
@@ -27,4 +27,8 @@ export function addressChannelsFor(hasChannels: HasChannels, ctx: HandlerContext
 export function messageDestinations(hasChannels: HasChannels, ctx: HandlerContext): Destination {
     const channels = hasChannels.channels.map(c => c.name);
     return addressSlackChannels(ctx.teamId, ...channels);
+}
+
+export function addressDestination(destination: Destination, ctx: HandlerContext): AddressChannels {
+    return (msg, opts) => ctx.messageClient.send(msg, destination, opts);
 }


### PR DESCRIPTION
When an endpoint verification fails, it posts a message now, with a Retry button. When pushed, that command calls the verification again.

It doesn't yet update the message when you push the button. That is not ideal, but we can live with it for now. At least we have a way to retry.