### PR TITLE
When endpoint not found in CF deploy, print log

### DIFF
--- a/src/handlers/commands/reportRunning.ts
+++ b/src/handlers/commands/reportRunning.ts
@@ -90,7 +90,7 @@ function countBy<T>(f: (T) => string, data: T[]): { [key: string]: number } {
 function describeCurrentlyRunning(id: RemoteRepoRef, countBySha: CountBySha, endDescription?: string): string {
     const shas = Object.keys(countBySha);
     if (shas.length === 0) {
-        return "No running services recorded";
+        return `It looks like ${id.repo} is not yet running in production. It should be safe to deploy.`;
     }
     return shas.map(s => `${countBySha[s]} reported running at ${linkToSha(id, s)} ${
         s === id.sha ? (endDescription ? "(" + endDescription + ")" : "") : linkToDiff(id, s, id.sha, endDescription)}`).join("\n");

--- a/src/handlers/events/delivery/deploy/deploy.ts
+++ b/src/handlers/events/delivery/deploy/deploy.ts
@@ -90,6 +90,14 @@ export async function deploy<T extends TargetInfo>(params: DeployParams<T>): Pro
                     logger.error("Could not set Endpoint status: " + endpointStatus.message);
                     // do not fail this whole handler
                 });
+        } else {
+            await params.ac("Deploy succeeded, but the endpoint didn't appear in the log.");
+            await params.ac({
+                content: progressLog.log,
+                fileType: "text",
+                fileName: `deploy-success-${params.id.sha}.log`,
+            } as any);
+            logger.warn("No endpoint returned by deployment")
         }
     } catch (err) {
         logger.error(err.message);

--- a/src/software-delivery-machine/blueprint/deploy/describeRunningServices.ts
+++ b/src/software-delivery-machine/blueprint/deploy/describeRunningServices.ts
@@ -10,5 +10,5 @@ export const PCFProductionDomain = "ri-production";
 
 export const DescribeStagingAndProd: () => HandleCommand<ReportRunningParameters> = () => reportRunningCommand(
     [
-        {domain: K8sTestingDomain, color: "#aa93c4"},
-        {domain: K8sProductionDomain, color: ProductionMauve}]);
+        {domain: PCFTestingDomain, color: "#aa93c4"},
+        {domain: PCFProductionDomain, color: ProductionMauve}]);

--- a/src/util/slack/reportFailureInterpretation.ts
+++ b/src/util/slack/reportFailureInterpretation.ts
@@ -2,7 +2,6 @@ import { RemoteRepoRef } from "@atomist/automation-client/operations/common/Repo
 import * as slack from "@atomist/slack-messages/SlackMessages";
 import { AddressChannels } from "../../common/slack/addressChannels";
 import { InterpretedLog } from "../../spi/log/InterpretedLog";
-import { ProgressLog } from "../../spi/log/ProgressLog";
 
 export async function reportFailureInterpretation(stepName: string,
                                                   interpretation: InterpretedLog,


### PR DESCRIPTION
@cdupuis Merge this and you'll get better diagnostics. The whole thing doesn't work for me, but this way if it doesn't find the endpoint it'll ship you the log so you can debug it.

It's trying to find the endpoint in the log with this grammar: https://github.com/atomist/github-sdm/blob/b3deec7f928c3ac8e0059d04bbcef4e22c8ab1b8/src/handlers/events/delivery/deploy/pcf/cloudFoundryLogParser.ts#L21-25