### PR TITLE
applyHttpServiceGoals is not an editor

### DIFF
--- a/src/software-delivery-machine/springSdmConfig.ts
+++ b/src/software-delivery-machine/springSdmConfig.ts
@@ -47,7 +47,6 @@ export function configureSpringSdm(softwareDeliveryMachine: SoftwareDeliveryMach
         .addClosedIssueListeners(thankYouYouRock)
         .addEditors(
             () => tryToUpgradeSpringBootVersion,
-            () => applyHttpServiceGoals,
             () => applyApacheLicenseHeaderEditor,
         )
         .addGenerators(() => springBootGenerator({
@@ -57,7 +56,8 @@ export function configureSpringSdm(softwareDeliveryMachine: SoftwareDeliveryMach
         .addNewRepoWithCodeActions(
             tagRepo(springBootTagger),
             PublishNewRepo)
-        .addReviewerRegistrations(logReview);
+        .addReviewerRegistrations(logReview)
+        .addSupportingCommands(() => applyHttpServiceGoals);
     if (opts.useCheckstyle) {
         const checkStylePath = process.env.CHECKSTYLE_PATH;
         if (!!checkStylePath) {


### PR DESCRIPTION
This doesn't really belong in spring config either, I don't think? 
but really, it should be general: we should be able to trigger any goal set.
... which is not urgent, so for now, here's a tiny bit of confusion avoided.