### PR TITLE
fix some remaining issues with deploying a spring app.

### DIFF
--- a/src/common/delivery/deploy/pcf/CloudFoundryApi.ts
+++ b/src/common/delivery/deploy/pcf/CloudFoundryApi.ts
@@ -201,6 +201,7 @@ export class CloudFoundryApi {
         }, {headers: _.assign({}, this.authHeader, this.jsonContentHeader)}),
             `create package ${appGuid}`);
         const formData = FormData();
+        formData.maxDataSize = Infinity;
         formData.append("bits", packageFile);
         const uploadHeaders = _.assign({}, this.authHeader, formData.getHeaders());
         const options = {
@@ -220,7 +221,7 @@ export class CloudFoundryApi {
                 await this.refreshToken();
                 return doWithRetry(() =>
                         axios.get(packageCreateResult.data.links.self.href, { headers: this.authHeader}),
-                    `get package ${appGuid}`);
+                    `get package ${packageCreateResult.data.guid}`);
             },
             r => r.data.state === "READY",
         );
@@ -239,7 +240,7 @@ export class CloudFoundryApi {
             async () => {
                 await this.refreshToken();
                 return doWithRetry(() => axios.get(buildResult.data.links.self.href, {headers: this.authHeader}),
-                    `get build for package ${packageGuid}`);
+                    `get build for package ${buildResult.data.guid}`);
                 },
                 r => r.data.state === "STAGED",
         );

--- a/src/common/delivery/deploy/pcf/CloudFoundryPushDeployer.ts
+++ b/src/common/delivery/deploy/pcf/CloudFoundryPushDeployer.ts
@@ -30,11 +30,11 @@ import { DeployableArtifact } from "../../../../spi/artifact/ArtifactStore";
 import { Deployer } from "../../../../spi/deploy/Deployer";
 import { InterpretedLog, LogInterpretation, LogInterpreter } from "../../../../spi/log/InterpretedLog";
 import { ProgressLog } from "../../../../spi/log/ProgressLog";
+import {ProjectLoader} from "../../../repo/ProjectLoader";
 import { CloudFoundryApi, initializeCloudFoundry } from "./CloudFoundryApi";
 import { Manifest } from "./CloudFoundryManifest";
 import { CloudFoundryPusher } from "./CloudFoundryPusher";
 import { CloudFoundryDeployment, CloudFoundryInfo, CloudFoundryManifestPath } from "./CloudFoundryTarget";
-import {ProjectLoader} from "../../../repo/ProjectLoader";
 
 /**
  * Use the Cloud Foundry API to approximate their CLI to push.
@@ -53,7 +53,7 @@ export class CloudFoundryPushDeployer implements Deployer<CloudFoundryInfo, Clou
 
     protected async archiveProject(p: GitProject, da: DeployableArtifact, log: ProgressLog): Promise<any> {
         if (!!da.filename) {
-            const archiveFile = `${p.baseDir}/target/${da.filename}`
+            const archiveFile = `${p.baseDir}/target/${da.filename}`;
             log.write(`Using archive ${archiveFile}`);
             // const packageFile = await p.findFile(archiveFile);
             return fs.createReadStream(`${p.baseDir}/target/${da.filename}`);

--- a/src/common/delivery/deploy/pcf/CloudFoundryPushDeployer.ts
+++ b/src/common/delivery/deploy/pcf/CloudFoundryPushDeployer.ts
@@ -34,6 +34,7 @@ import { CloudFoundryApi, initializeCloudFoundry } from "./CloudFoundryApi";
 import { Manifest } from "./CloudFoundryManifest";
 import { CloudFoundryPusher } from "./CloudFoundryPusher";
 import { CloudFoundryDeployment, CloudFoundryInfo, CloudFoundryManifestPath } from "./CloudFoundryTarget";
+import {ProjectLoader} from "../../../repo/ProjectLoader";
 
 /**
  * Use the Cloud Foundry API to approximate their CLI to push.
@@ -41,8 +42,7 @@ import { CloudFoundryDeployment, CloudFoundryInfo, CloudFoundryManifestPath } fr
  */
 export class CloudFoundryPushDeployer implements Deployer<CloudFoundryInfo, CloudFoundryDeployment> {
 
-    protected getProject(creds: ProjectOperationCredentials, repoRef: RemoteRepoRef): Promise<GitProject> {
-        return GitCommandGitProject.cloned(creds, repoRef);
+    constructor(private projectLoader: ProjectLoader) {
     }
 
     private async getManifest(p: Project): Promise<Manifest> {
@@ -51,75 +51,85 @@ export class CloudFoundryPushDeployer implements Deployer<CloudFoundryInfo, Clou
         return yaml.load(manifestContent);
     }
 
-    protected async archiveProject(baseDir: string): Promise<any> {
-        return new Promise((resolve, reject) => {
-            const packageFilePath = baseDir + "/cfpackage.zip";
-            const output = fs.createWriteStream(packageFilePath);
-            output.on("close", () => {
-                logger.info(`Created project archive ${packageFilePath}`);
-                const packageFile = fs.createReadStream(packageFilePath);
-                resolve(packageFile);
+    protected async archiveProject(p: GitProject, da: DeployableArtifact, log: ProgressLog): Promise<any> {
+        if (!!da.filename) {
+            const archiveFile = `${p.baseDir}/target/${da.filename}`
+            log.write(`Using archive ${archiveFile}`);
+            // const packageFile = await p.findFile(archiveFile);
+            return fs.createReadStream(`${p.baseDir}/target/${da.filename}`);
+        } else {
+            return new Promise((resolve, reject) => {
+                log.write(`creating archive for directory ${p.baseDir}`);
+                const packageFilePath = p.baseDir + "/cfpackage.zip";
+                const output = fs.createWriteStream(packageFilePath);
+                output.on("close", () => {
+                    logger.info(`Created project archive ${packageFilePath}`);
+                    const packageFile = fs.createReadStream(packageFilePath);
+                    resolve(packageFile);
+                });
+                const archive = archiver("zip", {
+                    store: true,
+                });
+                archive.pipe(output);
+                archive.directory(p.baseDir, false);
+                archive.on("error", err => {
+                    reject(err);
+                });
+                archive.finalize();
             });
-            const archive = archiver("zip", {
-                store: true,
-            });
-            archive.pipe(output);
-            archive.directory(baseDir, false);
-            archive.on("error", err => {
-                reject(err);
-            });
-            archive.finalize();
-        });
+        }
     }
 
     public async deploy(da: DeployableArtifact,
                         cfi: CloudFoundryInfo,
                         log: ProgressLog,
-                        creds: ProjectOperationCredentials,
+                        credentials: ProjectOperationCredentials,
                         team: string): Promise<CloudFoundryDeployment[]> {
         logger.info("Deploying app [%j] to Cloud Foundry [%j]", da, {...cfi, password: "REDACTED"});
         if (!cfi.api || !cfi.username || !cfi.password || !cfi.space) {
             throw new Error("cloud foundry authentication information missing. See CloudFoundryTarget.ts");
         }
-        const sources = await this.getProject(creds, da.id);
-        const packageFile = await this.archiveProject(sources.baseDir);
-        const manifest = await this.getManifest(sources);
-        const cfClient = await initializeCloudFoundry(cfi);
-        const cfApi = new CloudFoundryApi(cfClient);
-        const pusher = new CloudFoundryPusher(cfApi);
-        const deploymentPromises = manifest.applications.map(manifestApp => {
-            return pusher.push(cfi.space, manifestApp, packageFile, log);
+        return this.projectLoader.doWithProject({credentials, id: da.id, readOnly: false}, async project => {
+            const packageFile = await this.archiveProject(project, da, log);
+            const manifest = await this.getManifest(project);
+            const cfClient = await initializeCloudFoundry(cfi);
+            const cfApi = new CloudFoundryApi(cfClient);
+            const pusher = new CloudFoundryPusher(cfApi);
+            const deploymentPromises = manifest.applications.map(manifestApp => {
+                return pusher.push(cfi.space, manifestApp, packageFile, log);
+            });
+            return Promise.all(deploymentPromises);
         });
-        return Promise.all(deploymentPromises);
     }
 
     public async findDeployments(da: DeployableArtifact,
                                  cfi: CloudFoundryInfo,
-                                 creds: ProjectOperationCredentials): Promise<CloudFoundryDeployment[]> {
+                                 credentials: ProjectOperationCredentials): Promise<CloudFoundryDeployment[]> {
         if (!cfi.api || !cfi.username || !cfi.password || !cfi.space) {
             throw new Error("cloud foundry authentication information missing. See CloudFoundryTarget.ts");
         }
-        const sources = await this.getProject(creds, da.id);
-        const manifest = await this.getManifest(sources);
-        const cfClient = await initializeCloudFoundry(cfi);
-        const cfApi = new CloudFoundryApi(cfClient);
-        const pusher = new CloudFoundryPusher(cfApi);
-        const space = await cfApi.getSpaceByName(cfi.space);
-        const spaceGuid = space.metadata.guid;
-        const apps = manifest.applications.map(async manifestApp => {
-            const app = await cfApi.getApp(spaceGuid, manifestApp.name);
-            if (app) {
-                return manifestApp.name;
-            } else {
-                return undefined;
-            }
-        });
-        const appNames = _.compact(await Promise.all(apps));
-        return appNames.map(appName => {
-            return {
-                appName,
-                endpoint: pusher.constructEndpoint(appName),
-            } as CloudFoundryDeployment;
+        return this.projectLoader.doWithProject({credentials, id: da.id, readOnly: true}, async project => {
+            const manifest = await this.getManifest(project);
+            const cfClient = await initializeCloudFoundry(cfi);
+            const cfApi = new CloudFoundryApi(cfClient);
+            const pusher = new CloudFoundryPusher(cfApi);
+            const space = await cfApi.getSpaceByName(cfi.space);
+            const spaceGuid = space.metadata.guid;
+            const apps = manifest.applications.map(async manifestApp => {
+                const app = await cfApi.getApp(spaceGuid, manifestApp.name);
+                if (app) {
+                    return manifestApp.name;
+                } else {
+                    return undefined;
+                }
+            });
+            const appNames = _.compact(await Promise.all(apps));
+            return appNames.map(appName => {
+                return {
+                    appName,
+                    endpoint: pusher.constructEndpoint(appName),
+                } as CloudFoundryDeployment;
+            });
         });
     }
 

--- a/src/common/delivery/deploy/pcf/CloudFoundryPusher.ts
+++ b/src/common/delivery/deploy/pcf/CloudFoundryPusher.ts
@@ -51,7 +51,8 @@ export class CloudFoundryPusher {
         const packageUploadResult = await this.api.uploadPackage(appGuid, packageFile);
         log.write(`Building package for ${appNameForLog}...`);
         const buildResult = await this.api.buildDroplet(packageUploadResult.data.guid);
-        const serviceModifications = await this.appServiceModifications(appGuid, manifestApp.services);
+        const serviceNames = !manifestApp.services ? [] : manifestApp.services;
+        const serviceModifications = await this.appServiceModifications(appGuid, serviceNames);
         await this.api.stopApp(appGuid);
         log.write(`Stopped app for updates to ${appNameForLog}.`);
         await this.api.setCurrentDropletForApp(appGuid, buildResult.data.droplet.guid);


### PR DESCRIPTION
This jar size was larger than anything that I deployed before and I had to get around the default size limit.
I used the new project loader rather than cloning the project myself. This give me access to the jar so that I don't have to build it again.
If there is a filename specified in the DeployableArtifact, then use that as an archive.
small fix for when no services are specified in the manifest.yml.