### PR TITLE
most of status updates are goals

### DIFF
--- a/src/blueprint/SoftwareDeliveryMachine.ts
+++ b/src/blueprint/SoftwareDeliveryMachine.ts
@@ -477,7 +477,7 @@ export class SoftwareDeliveryMachine implements NewRepoHandling, ReferenceDelive
         this.goalSetters = goalSetters;
         addGitHubSupport(this);
         this.addSupportingCommands(selfDescribeHandler(this));
-        this.addFunctionalUnits(functionalUnitForGoal("DoNothing", NoGoal, executeImmaterial))
+        this.addFunctionalUnits(functionalUnitForGoal("DoNothing", NoGoal, executeImmaterial));
     }
 
 }

--- a/src/blueprint/SoftwareDeliveryMachine.ts
+++ b/src/blueprint/SoftwareDeliveryMachine.ts
@@ -24,7 +24,7 @@ import {
     FingerprintGoal,
     JustBuildGoal,
     LocalDeploymentGoal,
-    LocalEndpointGoal,
+    LocalEndpointGoal, NoGoal,
     ProductionDeploymentGoal,
     ProductionEndpointGoal,
     ReviewGoal,
@@ -81,7 +81,7 @@ import { selfDescribeHandler } from "../handlers/commands/SelfDescribe";
 import { displayBuildLogHandler } from "../handlers/commands/ShowBuildLog";
 import { ExecuteGoalOnRequested } from "../handlers/events/delivery/ExecuteGoalOnRequested";
 import { ExecuteGoalOnSuccessStatus } from "../handlers/events/delivery/ExecuteGoalOnSuccessStatus";
-import { SetGoalsOnPush } from "../handlers/events/delivery/goals/SetGoalsOnPush";
+import { executeImmaterial, SetGoalsOnPush } from "../handlers/events/delivery/goals/SetGoalsOnPush";
 import { OnSupersededStatus } from "../handlers/events/delivery/superseded/OnSuperseded";
 import { SetSupersededStatus } from "../handlers/events/delivery/superseded/SetSupersededStatus";
 import { ClosedIssueHandler } from "../handlers/events/issue/ClosedIssueHandler";
@@ -477,6 +477,7 @@ export class SoftwareDeliveryMachine implements NewRepoHandling, ReferenceDelive
         this.goalSetters = goalSetters;
         addGitHubSupport(this);
         this.addSupportingCommands(selfDescribeHandler(this));
+        this.addFunctionalUnits(functionalUnitForGoal("DoNothing", NoGoal, executeImmaterial))
     }
 
 }

--- a/src/common/delivery/deploy/deploy.ts
+++ b/src/common/delivery/deploy/deploy.ts
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-import { logger } from "@atomist/automation-client";
-import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
-import { ProjectOperationCredentials, TokenCredentials } from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
+import { HandlerContext, logger } from "@atomist/automation-client";
+import { ProjectOperationCredentials } from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import { ArtifactStore, DeployableArtifact } from "../../../spi/artifact/ArtifactStore";
 import { Deployer } from "../../../spi/deploy/Deployer";
 import { Deployment, TargetInfo } from "../../../spi/deploy/Deployment";
 import { ProgressLog } from "../../../spi/log/ProgressLog";
-import { StatusState } from "../../../typings/types";
-import { GitHubStatusContext } from "../goals/gitHubContext";
 import { Goal } from "../goals/Goal";
-
-import { createStatus } from "../../../util/github/ghub";
+import { descriptionFromState, updateGoal } from "../goals/storeGoals";
+import { RunWithLogContext } from "./runWithLog";
+import { findSdmGoalOnCommit } from "../goals/fetchGoalsOnCommit";
+import { providerIdFromStatus } from "../../../util/git/repoRef";
+import { SdmGoal, SdmGoalState } from "../../../ingesters/sdmGoalIngester";
 
 export type Targeter<T extends TargetInfo> = (id: RemoteRepoRef, branch: string) => T;
 
@@ -72,39 +72,35 @@ function sourceArtifact(id: RemoteRepoRef): DeployableArtifact {
     };
 }
 
-export async function setEndpointStatusOnSuccessfulDeploy(params: {
-                                                              endpointGoal: Goal,
-                                                              credentials: ProjectOperationCredentials,
-                                                              id: RemoteRepoRef,
-                                                          },
-                                                          deployment: Deployment) {
-
+export async function setEndpointGoalOnSuccessfulDeploy(params: {
+    endpointGoal: Goal,
+    rwlc: RunWithLogContext,
+    deployment: Deployment
+},) {
+    const {rwlc, deployment, endpointGoal} = params;
+    const sdmGoal = await findSdmGoalOnCommit(rwlc.context, rwlc.id, providerIdFromStatus(rwlc.status), endpointGoal);
     if (deployment.endpoint) {
-        await setStatus(params.credentials, params.id,
-            StatusState.success,
-            params.endpointGoal.context,
-            deployment.endpoint,
-            params.endpointGoal.successDescription)
-            .catch(endpointStatus => {
-                logger.error("Could not set Endpoint status: " + endpointStatus.message);
-                // do not fail this whole handler
-            });
+        const newState = "success";
+        await markEndpointStatus({context: rwlc.context, sdmGoal, endpointGoal, newState, endpoint: deployment.endpoint})
     } else {
-        throw new Error("Deploy finished with success, but the endpoint was not found in the logs");
+        const error = new Error("Deploy finished with success, but the endpoint was not found");
+        const newState = "failure";
+        await markEndpointStatus({context: rwlc.context, sdmGoal, endpointGoal, newState, endpoint: deployment.endpoint, error})
     }
 }
 
-export function setStatus(credentials: ProjectOperationCredentials,
-                          id: RemoteRepoRef,
-                          state: StatusState,
-                          context: GitHubStatusContext,
-                          targetUrl: string,
-                          description?: string): Promise<any> {
-    logger.info("Setting deploy status for %s to %s at %s", context, state, targetUrl);
-    return createStatus((credentials as TokenCredentials).token, id as GitHubRepoRef, {
-        state,
-        target_url: targetUrl,
-        context,
-        description,
+function markEndpointStatus(parameters: {
+    context: HandlerContext, sdmGoal: SdmGoal, endpointGoal: Goal, newState: SdmGoalState, endpoint?: string,
+    error?: Error
+}) {
+    let {context, sdmGoal, endpointGoal, newState, endpoint, error} = parameters;
+    return updateGoal(context, sdmGoal, {
+        description: descriptionFromState(endpointGoal, newState),
+        url: endpoint,
+        state: newState,
+        error
+    }).catch(endpointStatus => {
+        logger.error("Could not set Endpoint status: " + endpointStatus.message);
+        // do not fail this whole handler
     });
 }

--- a/src/common/delivery/deploy/executeDeploy.ts
+++ b/src/common/delivery/deploy/executeDeploy.ts
@@ -21,7 +21,7 @@ import { PushMapping } from "../../listener/PushMapping";
 import { ProjectLoader } from "../../repo/ProjectLoader";
 import { Goal } from "../goals/Goal";
 import { ExecuteGoalResult, GoalExecutor } from "../goals/goalExecution";
-import { checkOutArtifact, setEndpointStatusOnSuccessfulDeploy, Target, Targeter } from "./deploy";
+import { checkOutArtifact, setEndpointGoalOnSuccessfulDeploy, Target, Targeter } from "./deploy";
 
 import * as _ from "lodash";
 import { Deployer } from "../../../spi/deploy/Deployer";
@@ -87,8 +87,8 @@ export function executeDeploy(artifactStore: ArtifactStore,
                     credentials,
                     atomistTeam);
 
-                return Promise.all(deployments.map(deployment => setEndpointStatusOnSuccessfulDeploy(
-                    {endpointGoal, credentials, id}, deployment)));
+                return Promise.all(deployments.map(deployment => setEndpointGoalOnSuccessfulDeploy(
+                    {endpointGoal, rwlc, deployment})));
 
             });
         return Success;

--- a/src/common/delivery/deploy/executeDeploy.ts
+++ b/src/common/delivery/deploy/executeDeploy.ts
@@ -72,7 +72,8 @@ export function executeDeploy(artifactStore: ArtifactStore,
                 const target = await targetMapping.valueForPush(pti);
                 if (!target) {
                     progressLog.write("SDM configuration error: no deploy rule applies to this code");
-                    throw new Error(`Don't know how to deploy project ${id.owner}:${id.repo}`);
+                    logger.error(`Don't know how to deploy project ${id.owner}:${id.repo}`);
+                    return Success;
                 }
                 logger.info("Deploying project %s:%s with target [%j]", id.owner, id.repo, target);
 

--- a/src/common/delivery/goals/CopyGoalToGitHubStatus.ts
+++ b/src/common/delivery/goals/CopyGoalToGitHubStatus.ts
@@ -19,7 +19,7 @@ import { subscription } from "@atomist/automation-client/graph/graphQL";
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import { forApproval } from "../../../handlers/events/delivery/verify/approvalGate";
 import * as GoalEvent from "../../../ingesters/sdmGoalIngester";
-import { GoalState } from "../../../ingesters/sdmGoalIngester";
+import { SdmGoalState } from "../../../ingesters/sdmGoalIngester";
 import { OnAnyGoal, ScmProvider, StatusState } from "../../../typings/types";
 import { createStatus, State } from "../../../util/github/ghub";
 import { fetchProvider } from "../../../util/github/gitHubProvider";
@@ -43,7 +43,7 @@ export class CopyGoalToGitHubStatus implements HandleEvent<OnAnyGoal.Subscriptio
         // For now, skip in_process updates. Someday we may change this,
         // when it's SdmGoals that are displayed in lifecycle and only some
         // of them are copied to statuses. #98
-        if ((goal.state as GoalState) === "in_process") {
+        if ((goal.state as SdmGoalState) === "in_process") {
             logger.debug("Skipping update to %s because in_process updates aren't important enough", goal.externalKey);
             return Success;
         }
@@ -57,7 +57,7 @@ export class CopyGoalToGitHubStatus implements HandleEvent<OnAnyGoal.Subscriptio
             branch: goal.branch,
         });
 
-        const goalState = goal.state as GoalEvent.GoalState;
+        const goalState = goal.state as GoalEvent.SdmGoalState;
 
         const url = goalState === "waiting_for_approval" ? forApproval(goal.url || "https://pretend.atomist.com") : goal.url;
 
@@ -73,7 +73,7 @@ export class CopyGoalToGitHubStatus implements HandleEvent<OnAnyGoal.Subscriptio
 
 }
 
-export function sdmGoalStateToGitHubStatusState(goalState: GoalState): StatusState {
+export function sdmGoalStateToGitHubStatusState(goalState: SdmGoalState): StatusState {
     switch (goalState) {
         case "planned":
         case "requested":

--- a/src/common/delivery/goals/common/commonGoals.ts
+++ b/src/common/delivery/goals/common/commonGoals.ts
@@ -164,7 +164,6 @@ export const NoGoal = new Goal({
     orderedName: "1-immaterial",
     displayName: "immaterial",
     completedDescription: "No material changes",
-
 });
 
 export const StagingDeploymentContext = StagingDeploymentGoal.context;

--- a/src/common/delivery/goals/fetchGoalsOnCommit.ts
+++ b/src/common/delivery/goals/fetchGoalsOnCommit.ts
@@ -17,11 +17,11 @@
 import { HandlerContext, logger } from "@atomist/automation-client";
 import { SdmGoalsForCommit } from "../../../typings/types";
 
+import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import * as _ from "lodash";
 import { SdmGoal } from "../../../ingesters/sdmGoalIngester";
-import { goalCorrespondsToSdmGoal } from "./storeGoals";
 import { Goal } from "./Goal";
-import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
+import { goalCorrespondsToSdmGoal } from "./storeGoals";
 
 export async function findSdmGoalOnCommit(ctx: HandlerContext, id: RemoteRepoRef, providerId: string, goal: Goal): Promise<SdmGoal> {
     const sdmGoals = await fetchGoalsForCommit(ctx, id, providerId);

--- a/src/common/delivery/goals/storeGoals.ts
+++ b/src/common/delivery/goals/storeGoals.ts
@@ -20,7 +20,7 @@ import { addressEvent } from "@atomist/automation-client/spi/message/MessageClie
 import * as _ from "lodash";
 import { sprintf } from "sprintf-js";
 import { disregardApproval, requiresApproval } from "../../../handlers/events/delivery/verify/approvalGate";
-import { GoalRootType, SdmGoalState, SdmGoal, SdmGoalKey, SdmProvenance } from "../../../ingesters/sdmGoalIngester";
+import { GoalRootType, SdmGoal, SdmGoalKey, SdmGoalState, SdmProvenance } from "../../../ingesters/sdmGoalIngester";
 import { Goal, hasPreconditions } from "./Goal";
 
 export function environmentFromGoal(goal: Goal) {

--- a/src/common/delivery/goals/storeGoals.ts
+++ b/src/common/delivery/goals/storeGoals.ts
@@ -20,7 +20,7 @@ import { addressEvent } from "@atomist/automation-client/spi/message/MessageClie
 import * as _ from "lodash";
 import { sprintf } from "sprintf-js";
 import { disregardApproval, requiresApproval } from "../../../handlers/events/delivery/verify/approvalGate";
-import { GoalRootType, GoalState, SdmGoal, SdmGoalKey, SdmProvenance } from "../../../ingesters/sdmGoalIngester";
+import { GoalRootType, SdmGoalState, SdmGoal, SdmGoalKey, SdmProvenance } from "../../../ingesters/sdmGoalIngester";
 import { Goal, hasPreconditions } from "./Goal";
 
 export function environmentFromGoal(goal: Goal) {
@@ -28,7 +28,7 @@ export function environmentFromGoal(goal: Goal) {
 }
 
 export interface UpdateSdmGoalParams {
-    state: GoalState;
+    state: SdmGoalState;
     description: string;
     url?: string;
     approved?: boolean;
@@ -59,7 +59,7 @@ export function goalCorrespondsToSdmGoal(goal: Goal, sdmGoal: SdmGoal): boolean 
 export function storeGoal(ctx: HandlerContext, parameters: {
     goalSet: string,
     goal: Goal,
-    state: GoalState,
+    state: SdmGoalState,
     id: GitHubRepoRef,
     providerId: string
     url?: string,
@@ -127,7 +127,7 @@ function constructProvenance(ctx: HandlerContext): SdmProvenance {
     };
 }
 
-export function descriptionFromState(goal: Goal, state: GoalState): string {
+export function descriptionFromState(goal: Goal, state: SdmGoalState): string {
     switch (state) {
         case  "planned" :
         case "requested" :

--- a/src/graphql/subscription/OnBuildComplete.graphql
+++ b/src/graphql/subscription/OnBuildComplete.graphql
@@ -9,17 +9,7 @@ subscription OnBuildComplete {
       sha
       message
       repo {
-        name
-        owner
-        gitHubId
-        allowRebaseMerge
-        channels {
-          team {
-            id
-          }
-          name
-          id
-        }
+        ...CoreRepoFieldsAndChannels
       }
       statuses {
         context

--- a/src/graphql/subscription/OnBuildCompleteForDryRun.graphql
+++ b/src/graphql/subscription/OnBuildCompleteForDryRun.graphql
@@ -9,16 +9,7 @@ subscription OnBuildCompleteForDryRun {
       sha
       message
       repo {
-        name
-        owner
-        gitHubId
-        allowRebaseMerge
-        channels {
-          team {
-            id
-          }
-          id
-        }
+        ...CoreRepoFieldsAndChannels
       }
       pushes {
         branch

--- a/src/graphql/subscription/OnImageLinked.graphql
+++ b/src/graphql/subscription/OnImageLinked.graphql
@@ -13,7 +13,7 @@ subscription OnImageLinked {
         }
       }
       repo {
-       ...CoreRepoFieldsAndChannels
+        ...CoreRepoFieldsAndChannels
       }
       statuses {
         context

--- a/src/graphql/subscription/OnImageLinked.graphql
+++ b/src/graphql/subscription/OnImageLinked.graphql
@@ -13,20 +13,7 @@ subscription OnImageLinked {
         }
       }
       repo {
-        owner
-        name
-        channels {
-          team {
-            id
-          }
-          name
-          id
-        }
-        org {
-          chatTeam {
-            id
-          }
-        }
+       ...CoreRepoFieldsAndChannels
       }
       statuses {
         context

--- a/src/handlers/events/delivery/ExecuteGoalOnRequested.ts
+++ b/src/handlers/events/delivery/ExecuteGoalOnRequested.ts
@@ -22,7 +22,7 @@ import { sdmGoalStateToGitHubStatusState } from "../../../common/delivery/goals/
 import { Goal } from "../../../common/delivery/goals/Goal";
 import { ExecuteGoalInvocation, GoalExecutor } from "../../../common/delivery/goals/goalExecution";
 import { environmentFromGoal } from "../../../common/delivery/goals/storeGoals";
-import { SdmGoalState, SdmGoal } from "../../../ingesters/sdmGoalIngester";
+import { SdmGoal, SdmGoalState } from "../../../ingesters/sdmGoalIngester";
 import { CommitForSdmGoal, OnRequestedSdmGoal, SdmGoalFields, StatusForExecuteGoal } from "../../../typings/types";
 import { executeGoal, validSubscriptionName } from "./verify/executeGoal";
 

--- a/src/handlers/events/delivery/ExecuteGoalOnRequested.ts
+++ b/src/handlers/events/delivery/ExecuteGoalOnRequested.ts
@@ -22,7 +22,7 @@ import { sdmGoalStateToGitHubStatusState } from "../../../common/delivery/goals/
 import { Goal } from "../../../common/delivery/goals/Goal";
 import { ExecuteGoalInvocation, GoalExecutor } from "../../../common/delivery/goals/goalExecution";
 import { environmentFromGoal } from "../../../common/delivery/goals/storeGoals";
-import { GoalState, SdmGoal } from "../../../ingesters/sdmGoalIngester";
+import { SdmGoalState, SdmGoal } from "../../../ingesters/sdmGoalIngester";
 import { CommitForSdmGoal, OnRequestedSdmGoal, SdmGoalFields, StatusForExecuteGoal } from "../../../typings/types";
 import { executeGoal, validSubscriptionName } from "./verify/executeGoal";
 
@@ -85,7 +85,7 @@ export class ExecuteGoalOnRequested implements HandleEvent<OnRequestedSdmGoal.Su
 function convertForNow(sdmGoal: SdmGoalFields.Fragment, commit: CommitForSdmGoal.Commit): StatusForExecuteGoal.Fragment {
     return {
         commit,
-        state: sdmGoalStateToGitHubStatusState(sdmGoal.state as GoalState),
+        state: sdmGoalStateToGitHubStatusState(sdmGoal.state as SdmGoalState),
         targetUrl: sdmGoal.url, // not handling approval weirdness
         context: sdmGoal.externalKey,
         description: sdmGoal.description,

--- a/src/handlers/events/delivery/build/FindArtifactOnImageLinked.ts
+++ b/src/handlers/events/delivery/build/FindArtifactOnImageLinked.ts
@@ -27,7 +27,9 @@ import {
 } from "@atomist/automation-client";
 import { subscription } from "@atomist/automation-client/graph/graphQL";
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
+import { findSdmGoalOnCommit } from "../../../../common/delivery/goals/fetchGoalsOnCommit";
 import { Goal } from "../../../../common/delivery/goals/Goal";
+import { updateGoal } from "../../../../common/delivery/goals/storeGoals";
 import {
     ArtifactInvocation,
     ArtifactListener,
@@ -35,8 +37,6 @@ import {
 import { addressChannelsFor } from "../../../../common/slack/addressChannels";
 import { ArtifactStore } from "../../../../spi/artifact/ArtifactStore";
 import { OnImageLinked } from "../../../../typings/types";
-import { findSdmGoalOnCommit } from "../../../../common/delivery/goals/fetchGoalsOnCommit";
-import { updateGoal } from "../../../../common/delivery/goals/storeGoals";
 
 @EventHandler("Scan when artifact is found", subscription("OnImageLinked"))
 export class FindArtifactOnImageLinked implements HandleEvent<OnImageLinked.Subscription> {

--- a/src/handlers/events/delivery/build/FindArtifactOnImageLinked.ts
+++ b/src/handlers/events/delivery/build/FindArtifactOnImageLinked.ts
@@ -35,7 +35,6 @@ import {
 import { addressChannelsFor } from "../../../../common/slack/addressChannels";
 import { ArtifactStore } from "../../../../spi/artifact/ArtifactStore";
 import { OnImageLinked } from "../../../../typings/types";
-import { createStatus } from "../../../../util/github/ghub";
 import { findSdmGoalOnCommit } from "../../../../common/delivery/goals/fetchGoalsOnCommit";
 import { updateGoal } from "../../../../common/delivery/goals/storeGoals";
 

--- a/src/handlers/events/delivery/build/SetStatusOnBuildComplete.ts
+++ b/src/handlers/events/delivery/build/SetStatusOnBuildComplete.ts
@@ -14,46 +14,20 @@
  * limitations under the License.
  */
 
-import {
-    EventFired,
-    EventHandler,
-    HandleEvent,
-    HandlerContext,
-    HandlerResult,
-    logger,
-    Secret,
-    Secrets,
-    Success,
-} from "@atomist/automation-client";
+import { EventFired, EventHandler, HandleEvent, HandlerContext, HandlerResult, logger, Secret, Secrets, Success, } from "@atomist/automation-client";
 import { subscription } from "@atomist/automation-client/graph/graphQL";
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
-import {
-    ProjectOperationCredentials,
-    TokenCredentials,
-} from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import * as slack from "@atomist/slack-messages/SlackMessages";
 import axios from "axios";
 import * as stringify from "json-stringify-safe";
-import { NotARealUrl } from "../../../../common/delivery/build/local/LocalBuilder";
 import { Goal } from "../../../../common/delivery/goals/Goal";
-import {
-    AddressChannels,
-    addressChannelsFor,
-} from "../../../../common/slack/addressChannels";
+import { AddressChannels, addressChannelsFor, } from "../../../../common/slack/addressChannels";
 import { LogInterpretation } from "../../../../spi/log/InterpretedLog";
-import {
-    BuildStatus,
-    OnBuildComplete,
-} from "../../../../typings/types";
-import {
-    createStatus,
-    State,
-} from "../../../../util/github/ghub";
+import { BuildStatus, OnBuildComplete, } from "../../../../typings/types";
 import { reportFailureInterpretation } from "../../../../util/slack/reportFailureInterpretation";
-import { ExecuteGoalResult } from "../../../../common/delivery/goals/goalExecution";
 import { descriptionFromState, updateGoal } from "../../../../common/delivery/goals/storeGoals";
-import { SdmGoalState, SdmGoal } from "../../../../ingesters/sdmGoalIngester";
+import { SdmGoal, SdmGoalState } from "../../../../ingesters/sdmGoalIngester";
 import { findSdmGoalOnCommit } from "../../../../common/delivery/goals/fetchGoalsOnCommit";
 
 /**

--- a/src/handlers/events/delivery/build/SetStatusOnBuildComplete.ts
+++ b/src/handlers/events/delivery/build/SetStatusOnBuildComplete.ts
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-import { EventFired, EventHandler, HandleEvent, HandlerContext, HandlerResult, logger, Secret, Secrets, Success, } from "@atomist/automation-client";
+import { EventFired, EventHandler, HandleEvent, HandlerContext, HandlerResult, logger, Secret, Secrets, Success } from "@atomist/automation-client";
 import { subscription } from "@atomist/automation-client/graph/graphQL";
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import * as slack from "@atomist/slack-messages/SlackMessages";
 import axios from "axios";
 import * as stringify from "json-stringify-safe";
-import { Goal } from "../../../../common/delivery/goals/Goal";
-import { AddressChannels, addressChannelsFor, } from "../../../../common/slack/addressChannels";
-import { LogInterpretation } from "../../../../spi/log/InterpretedLog";
-import { BuildStatus, OnBuildComplete, } from "../../../../typings/types";
-import { reportFailureInterpretation } from "../../../../util/slack/reportFailureInterpretation";
-import { descriptionFromState, updateGoal } from "../../../../common/delivery/goals/storeGoals";
-import { SdmGoal, SdmGoalState } from "../../../../ingesters/sdmGoalIngester";
 import { findSdmGoalOnCommit } from "../../../../common/delivery/goals/fetchGoalsOnCommit";
+import { Goal } from "../../../../common/delivery/goals/Goal";
+import { descriptionFromState, updateGoal } from "../../../../common/delivery/goals/storeGoals";
+import { AddressChannels, addressChannelsFor } from "../../../../common/slack/addressChannels";
+import { SdmGoal, SdmGoalState } from "../../../../ingesters/sdmGoalIngester";
+import { LogInterpretation } from "../../../../spi/log/InterpretedLog";
+import { BuildStatus, OnBuildComplete } from "../../../../typings/types";
+import { reportFailureInterpretation } from "../../../../util/slack/reportFailureInterpretation";
 
 /**
  * Set build status on complete build
@@ -117,7 +117,7 @@ async function setBuiltContext(ctx: HandlerContext,
                                goal: Goal,
                                sdmGoal: SdmGoal,
                                state: BuildStatus,
-                               url: string,): Promise<any> {
+                               url: string): Promise<any> {
     const newState = buildStatusToSdmGoalState(state);
     return updateGoal(ctx, sdmGoal as SdmGoal,
         {

--- a/src/handlers/events/delivery/deploy/k8s/RequestK8sDeploys.ts
+++ b/src/handlers/events/delivery/deploy/k8s/RequestK8sDeploys.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { failure, HandlerContext, logger } from "@atomist/automation-client";
+import { failure, HandlerContext, logger, Success } from "@atomist/automation-client";
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import { ProjectOperationCredentials, TokenCredentials } from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
 import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
@@ -47,6 +47,7 @@ export function requestDeployToK8s(target: K8Target): GoalExecutor {
             state: "pending",
             description: "Requested deploy by k8-automation",
         });
+        return Success;
     };
 }
 

--- a/src/handlers/events/delivery/goals/SetGoalsOnPush.ts
+++ b/src/handlers/events/delivery/goals/SetGoalsOnPush.ts
@@ -31,8 +31,9 @@ import {
 import { Parameters } from "@atomist/automation-client/decorators";
 import { subscription } from "@atomist/automation-client/graph/graphQL";
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
-import { ProjectOperationCredentials, } from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
+import { ProjectOperationCredentials } from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
 import { GitProject } from "@atomist/automation-client/project/git/GitProject";
+import { GoalExecutor } from "../../../../common/delivery/goals/goalExecution";
 import { Goals } from "../../../../common/delivery/goals/Goals";
 import { GoalSetter } from "../../../../common/listener/GoalSetter";
 import { GoalsSetInvocation, GoalsSetListener } from "../../../../common/listener/GoalsSetListener";
@@ -43,7 +44,6 @@ import { ProjectLoader } from "../../../../common/repo/ProjectLoader";
 import { addressChannelsFor } from "../../../../common/slack/addressChannels";
 import { OnPushToAnyBranch, PushFields } from "../../../../typings/types";
 import { providerIdFromPush, repoRefFromPush } from "../../../../util/git/repoRef";
-import { GoalExecutor } from "../../../../common/delivery/goals/goalExecution";
 
 /**
  * Set up goalSet on a push (e.g. for delivery).

--- a/src/handlers/events/delivery/goals/SetGoalsOnPush.ts
+++ b/src/handlers/events/delivery/goals/SetGoalsOnPush.ts
@@ -48,6 +48,7 @@ import { addressChannelsFor } from "../../../../common/slack/addressChannels";
 import { OnPushToAnyBranch, PushFields } from "../../../../typings/types";
 import { providerIdFromPush, repoRefFromPush } from "../../../../util/git/repoRef";
 import { createStatus, tipOfDefaultBranch } from "../../../../util/github/ghub";
+import { GoalExecutor } from "../../../../common/delivery/goals/goalExecution";
 
 /**
  * Set up goalSet on a push (e.g. for delivery).
@@ -118,17 +119,13 @@ async function saveGoals(ctx: HandlerContext,
                          id: GitHubRepoRef,
                          providerId: string,
                          determinedGoals: Goals) {
-    if (determinedGoals === NoGoals) {
-        // TODO: let "Immaterial" be a goal instead of this special-case handling
-        await createStatus((credentials as TokenCredentials).token, id, {
-            context: "Immaterial",
-            state: "success",
-            description: "No significant change",
-        });
-    } else {
-        await determinedGoals.setAllToPending(id, ctx, providerId);
-    }
+    await determinedGoals.setAllToPending(id, ctx, providerId);
 }
+
+export const executeImmaterial: GoalExecutor = async () => {
+    logger.debug("Nothing to do here");
+    return Success;
+};
 
 async function setGoalsForPushOnProject(push: OnPushToAnyBranch.Push,
                                         id: GitHubRepoRef,

--- a/src/handlers/events/delivery/goals/SetGoalsOnPush.ts
+++ b/src/handlers/events/delivery/goals/SetGoalsOnPush.ts
@@ -31,12 +31,8 @@ import {
 import { Parameters } from "@atomist/automation-client/decorators";
 import { subscription } from "@atomist/automation-client/graph/graphQL";
 import { GitHubRepoRef } from "@atomist/automation-client/operations/common/GitHubRepoRef";
-import {
-    ProjectOperationCredentials,
-    TokenCredentials,
-} from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
+import { ProjectOperationCredentials, } from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
 import { GitProject } from "@atomist/automation-client/project/git/GitProject";
-import { NoGoals } from "../../../../common/delivery/goals/common/commonGoals";
 import { Goals } from "../../../../common/delivery/goals/Goals";
 import { GoalSetter } from "../../../../common/listener/GoalSetter";
 import { GoalsSetInvocation, GoalsSetListener } from "../../../../common/listener/GoalsSetListener";
@@ -47,7 +43,6 @@ import { ProjectLoader } from "../../../../common/repo/ProjectLoader";
 import { addressChannelsFor } from "../../../../common/slack/addressChannels";
 import { OnPushToAnyBranch, PushFields } from "../../../../typings/types";
 import { providerIdFromPush, repoRefFromPush } from "../../../../util/git/repoRef";
-import { createStatus, tipOfDefaultBranch } from "../../../../util/github/ghub";
 import { GoalExecutor } from "../../../../common/delivery/goals/goalExecution";
 
 /**

--- a/src/handlers/events/delivery/verify/executeVerifyEndpoint.ts
+++ b/src/handlers/events/delivery/verify/executeVerifyEndpoint.ts
@@ -60,6 +60,6 @@ export function executeVerifyEndpoint(sdm: SdmVerification): GoalExecutor {
             throw err;
         })));
 
-        return { code: 0, requireApproval: sdm.requestApproval};
+        return { code: 0, requireApproval: sdm.requestApproval, targetUrl: endpointStatus.targetUrl };
     }, lastTenLinesLogInterpreter("Verification failed"));
 }

--- a/src/ingesters/sdmGoalIngester.ts
+++ b/src/ingesters/sdmGoalIngester.ts
@@ -22,7 +22,7 @@ import {
 
 export const GoalRootType = "SdmGoal";
 
-export type GoalState = "planned" | "requested" | "in_process" | "waiting_for_approval" | "success" | "failure" | "skipped";
+export type SdmGoalState = "planned" | "requested" | "in_process" | "waiting_for_approval" | "success" | "failure" | "skipped";
 
 export interface SdmGoal extends SdmGoalKey {
     sha: string;
@@ -36,7 +36,7 @@ export interface SdmGoal extends SdmGoalKey {
 
     description: string;
     url?: string;
-    state: GoalState;
+    state: SdmGoalState;
     ts: number;
 
     error?: string;

--- a/src/software-delivery-machine/machines/k8sMachine.ts
+++ b/src/software-delivery-machine/machines/k8sMachine.ts
@@ -18,6 +18,7 @@ import * as build from "../../blueprint/dsl/buildDsl";
 import { whenPushSatisfies } from "../../blueprint/dsl/goalDsl";
 import { SoftwareDeliveryMachine, SoftwareDeliveryMachineOptions } from "../../blueprint/SoftwareDeliveryMachine";
 import { K8sAutomationBuilder } from "../../common/delivery/build/k8s/K8AutomationBuilder";
+import { NoGoal, NoGoals } from "../../common/delivery/goals/common/commonGoals";
 import { HttpServiceGoals, LocalDeploymentGoals } from "../../common/delivery/goals/common/httpServiceGoals";
 import { LibraryGoals } from "../../common/delivery/goals/common/libraryGoals";
 import { NpmBuildGoals, NpmDeployGoals } from "../../common/delivery/goals/common/npmGoals";
@@ -45,7 +46,6 @@ import { addJavaSupport, JavaSupportOptions } from "../parts/stacks/javaSupport"
 import { addNodeSupport } from "../parts/stacks/nodeSupport";
 import { addSpringSupport } from "../parts/stacks/springSupport";
 import { addTeamPolicies } from "../parts/team/teamPolicies";
-import { NoGoal, NoGoals } from "../../common/delivery/goals/common/commonGoals";
 
 export type K8sMachineOptions = SoftwareDeliveryMachineOptions & JavaSupportOptions;
 

--- a/src/software-delivery-machine/machines/k8sMachine.ts
+++ b/src/software-delivery-machine/machines/k8sMachine.ts
@@ -45,6 +45,7 @@ import { addJavaSupport, JavaSupportOptions } from "../parts/stacks/javaSupport"
 import { addNodeSupport } from "../parts/stacks/nodeSupport";
 import { addSpringSupport } from "../parts/stacks/springSupport";
 import { addTeamPolicies } from "../parts/team/teamPolicies";
+import { NoGoal, NoGoals } from "../../common/delivery/goals/common/commonGoals";
 
 export type K8sMachineOptions = SoftwareDeliveryMachineOptions & JavaSupportOptions;
 
@@ -52,6 +53,9 @@ export function k8sSoftwareDeliveryMachine(opts: K8sMachineOptions): SoftwareDel
     const sdm = new SoftwareDeliveryMachine(
         "K8s software delivery machine",
         opts,
+        whenPushSatisfies(IsMaven, not(MaterialChangeToJavaRepo))
+            .itMeans("Immaterial change")
+            .setGoals(NoGoals),
         whenPushSatisfies(
             ToDefaultBranch,
             IsMaven,


### PR DESCRIPTION
OK. This takes out the rest of the createStatus calls with a few exceptions:

- k8-automation communication needs reworked, so I didn't change that. We want it to trigger directly off of goals
- editor dry run continues to run with statuses
- Superseded is a status, that's a separate problem