### PR TITLE
Switch PCF deployer to API implementation

### DIFF
--- a/src/software-delivery-machine/blueprint/deploy/cloudFoundryDeploy.ts
+++ b/src/software-delivery-machine/blueprint/deploy/cloudFoundryDeploy.ts
@@ -15,6 +15,7 @@
  */
 
 import { DeploySpec } from "../../../common/delivery/deploy/executeDeploy";
+import {CloudFoundryPushDeployer} from "../../../common/delivery/deploy/pcf/CloudFoundryPushDeployer";
 import {
     CloudFoundryInfo,
 } from "../../../common/delivery/deploy/pcf/CloudFoundryTarget";
@@ -31,7 +32,6 @@ import { ProjectLoader } from "../../../common/repo/ProjectLoader";
 import { setDeployEnablement } from "../../../handlers/commands/SetDeployEnablement";
 import { ArtifactStore } from "../../../spi/artifact/ArtifactStore";
 import { AddCloudFoundryManifestMarker } from "../../commands/editors/pcf/addCloudFoundryManifest";
-import {CloudFoundryPushDeployer} from "../../../common/delivery/deploy/pcf/CloudFoundryPushDeployer";
 
 export const CloudFoundryStagingTarget = new EnvironmentCloudFoundryTarget("staging");
 

--- a/src/software-delivery-machine/blueprint/deploy/cloudFoundryDeploy.ts
+++ b/src/software-delivery-machine/blueprint/deploy/cloudFoundryDeploy.ts
@@ -31,6 +31,7 @@ import { ProjectLoader } from "../../../common/repo/ProjectLoader";
 import { setDeployEnablement } from "../../../handlers/commands/SetDeployEnablement";
 import { ArtifactStore } from "../../../spi/artifact/ArtifactStore";
 import { AddCloudFoundryManifestMarker } from "../../commands/editors/pcf/addCloudFoundryManifest";
+import {CloudFoundryPushDeployer} from "../../../common/delivery/deploy/pcf/CloudFoundryPushDeployer";
 
 export const CloudFoundryStagingTarget = new EnvironmentCloudFoundryTarget("staging");
 
@@ -45,7 +46,7 @@ export function cloudFoundryStagingDeploySpec(opts: {artifactStore: ArtifactStor
         deployGoal: StagingDeploymentGoal,
         endpointGoal: StagingEndpointGoal,
         artifactStore: opts.artifactStore,
-        deployer: new CommandLineCloudFoundryDeployer(opts.projectLoader),
+        deployer: new CloudFoundryPushDeployer(opts.projectLoader),
         targeter: () => CloudFoundryStagingTarget,
     };
 }
@@ -56,7 +57,7 @@ export function cloudFoundryProductionDeploySpec(opts: {artifactStore: ArtifactS
         deployGoal: ProductionDeploymentGoal,
         endpointGoal: ProductionEndpointGoal,
         artifactStore: opts.artifactStore,
-        deployer: new CommandLineCloudFoundryDeployer(opts.projectLoader),
+        deployer: new CloudFoundryPushDeployer(opts.projectLoader),
         targeter: () => CloudFoundryProductionTarget,
     };
 }


### PR DESCRIPTION
tested this with a locally running sdm and some minor modifications to make it work.
It still deploys the losgatos spring project.