### PR TITLE
Rolled back to the simpler goal finding logic.

### DIFF
--- a/src/common/listener/support/PushRules.ts
+++ b/src/common/listener/support/PushRules.ts
@@ -57,11 +57,7 @@ export class PushRules<V> implements PushMapping<V> {
                 logger.debug("Eligible PushRule named %s returned choice %j", pc.name, found);
                 return found;
             }));
-        const nonNull = results.find(p => !!p);
-        const indexOfNull = results.indexOf(null);
-        const value = indexOfNull > -1 && indexOfNull < results.indexOf(nonNull) ?
-            undefined :
-            nonNull;
+        const value = results.find(p => !!p);
 
         logger.info("PushRules [%s]: Value for push on %j is %j", this.name, pi.id, value);
         return value;


### PR DESCRIPTION
Otherwise, changes to the controller in losgatos1 returned undefined, and no goals were selected.
I'm sure this shouldn't be reverted, but I'm interested in understanding the intent of the index comparisons, and maybe I can put a unit test and solution in place that works for both. cases.