### PR TITLE
Initial Lein build support

### DIFF
--- a/src/common/delivery/build/local/lein/leinBuilder.ts
+++ b/src/common/delivery/build/local/lein/leinBuilder.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
+import { Project } from "@atomist/automation-client/project/Project";
+import { AppInfo } from "../../../../../spi/deploy/Deployment";
+import { LogInterpreter } from "../../../../../spi/log/InterpretedLog";
+import { asSpawnCommand, SpawnCommand } from "../../../../../util/misc/spawned";
+import { createEphemeralProgressLogWithConsole } from "../../../../log/EphemeralProgressLog";
+import { ProjectLoader } from "../../../../repo/ProjectLoader";
+import { SpawnBuilder, SpawnBuilderOptions } from "../SpawnBuilder";
+
+export const RunBuild: SpawnCommand = asSpawnCommand("lein");
+
+export function leinBuilder(projectLoader: ProjectLoader) {
+    return new SpawnBuilder(undefined,
+        createEphemeralProgressLogWithConsole,
+        projectLoader, leinBuilderOptions([RunBuild]));
+}
+
+export const leinLogInterpreter: LogInterpreter = log => {
+    const relevantPart = log.split("\n")
+        .filter(l => l.startsWith("ERROR") || l.includes("ERR!"))
+        .join("\n");
+    return {
+        relevantPart,
+        message: "npm errors",
+        includeFullLog: true,
+    };
+};
+
+export function leinBuilderOptions(commands: SpawnCommand[]): SpawnBuilderOptions {
+    return {
+        name: "LeinBuilder",
+        commands,
+        errorFinder: (code, signal, l) => {
+            return l.log.startsWith("[error]") || l.log.includes("ERR!");
+        },
+        logInterpreter: leinLogInterpreter,
+        async projectToAppInfo(p: Project): Promise<AppInfo> {
+            // const packageJson = await p.findFile("package.json");
+            // const content = await packageJson.getContent();
+            // const pkg = JSON.parse(content);
+            const name = "name";
+            const version = "version";
+            return {id: p.id as RemoteRepoRef, name, version};
+        },
+        options: {
+            env: {
+                ...process.env,
+                NODE_ENV: "development",
+            },
+        },
+    };
+}

--- a/src/common/delivery/build/local/lein/leinBuilder.ts
+++ b/src/common/delivery/build/local/lein/leinBuilder.ts
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
 import { Project } from "@atomist/automation-client/project/Project";
+import { Microgrammar } from "@atomist/microgrammar/Microgrammar";
 import { AppInfo } from "../../../../../spi/deploy/Deployment";
 import { LogInterpreter } from "../../../../../spi/log/InterpretedLog";
 import { asSpawnCommand, SpawnCommand } from "../../../../../util/misc/spawned";
 import { createEphemeralProgressLogWithConsole } from "../../../../log/EphemeralProgressLog";
 import { ProjectLoader } from "../../../../repo/ProjectLoader";
 import { SpawnBuilder, SpawnBuilderOptions } from "../SpawnBuilder";
-import { Microgrammar } from "@atomist/microgrammar/Microgrammar";
 
 export const RunBuild: SpawnCommand = asSpawnCommand("lein");
 

--- a/src/common/listener/support/pushtest/jvm/jvmPushTests.ts
+++ b/src/common/listener/support/pushtest/jvm/jvmPushTests.ts
@@ -17,6 +17,7 @@
 import { fileExists } from "@atomist/automation-client/project/util/projectUtils";
 import { AllJavaFiles } from "@atomist/spring-automation/commands/generator/java/javaProjectUtils";
 import { predicatePushTest, PredicatePushTest } from "../../../PushTest";
+import { hasFile } from "../commonPushTests";
 
 /**
  * Is this a Maven project
@@ -30,3 +31,10 @@ export const IsJava = predicatePushTest(
     "Is Java",
     async p =>
         fileExists(p, AllJavaFiles, () => true));
+
+export const IsClojure = predicatePushTest(
+    "Is Clojure",
+    async p =>
+        fileExists(p, "**/*.clj", () => true));
+
+export const IsLein = hasFile("project.clj");

--- a/src/common/log/S3ProgressLog.ts
+++ b/src/common/log/S3ProgressLog.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import S3StreamLogger = require("s3-streamlogger");
 import winston = require("winston");
 import { ProgressLog} from "../../spi/log/ProgressLog";

--- a/src/ingesters/sdmVersionIngester.ts
+++ b/src/ingesters/sdmVersionIngester.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const SdmVersionRootType = "SdmVersion";
 
 export interface SdmVersion {

--- a/src/software-delivery-machine/machines/cloudFoundryMachine.ts
+++ b/src/software-delivery-machine/machines/cloudFoundryMachine.ts
@@ -22,6 +22,7 @@ import {
     SoftwareDeliveryMachine,
     SoftwareDeliveryMachineOptions,
 } from "../../blueprint/SoftwareDeliveryMachine";
+import { leinBuilder } from "../../common/delivery/build/local/lein/leinBuilder";
 import { MavenBuilder } from "../../common/delivery/build/local/maven/MavenBuilder";
 import {
     nodeRunBuildBuilder,
@@ -63,7 +64,7 @@ import {
 } from "../../common/listener/support/pushtest/commonPushTests";
 import { IsDeployEnabled } from "../../common/listener/support/pushtest/deployPushTests";
 import { HasDockerfile } from "../../common/listener/support/pushtest/docker/dockerPushTests";
-import { IsClojure, IsLein, IsMaven } from "../../common/listener/support/pushtest/jvm/jvmPushTests";
+import { IsLein, IsMaven } from "../../common/listener/support/pushtest/jvm/jvmPushTests";
 import { MaterialChangeToJavaRepo } from "../../common/listener/support/pushtest/jvm/materialChangeToJavaRepo";
 import { HasSpringBootApplicationClass } from "../../common/listener/support/pushtest/jvm/springPushTests";
 import { NamedSeedRepo } from "../../common/listener/support/pushtest/NamedSeedRepo";
@@ -98,7 +99,6 @@ import {
 import { addNodeSupport } from "../parts/stacks/nodeSupport";
 import { addSpringSupport } from "../parts/stacks/springSupport";
 import { addTeamPolicies } from "../parts/team/teamPolicies";
-import { leinBuilder } from "../../common/delivery/build/local/lein/leinBuilder";
 
 export type CloudFoundryMachineOptions = SoftwareDeliveryMachineOptions & JavaSupportOptions & DockerOptions;
 

--- a/src/software-delivery-machine/machines/cloudFoundryMachine.ts
+++ b/src/software-delivery-machine/machines/cloudFoundryMachine.ts
@@ -63,7 +63,7 @@ import {
 } from "../../common/listener/support/pushtest/commonPushTests";
 import { IsDeployEnabled } from "../../common/listener/support/pushtest/deployPushTests";
 import { HasDockerfile } from "../../common/listener/support/pushtest/docker/dockerPushTests";
-import { IsMaven } from "../../common/listener/support/pushtest/jvm/jvmPushTests";
+import { IsClojure, IsLein, IsMaven } from "../../common/listener/support/pushtest/jvm/jvmPushTests";
 import { MaterialChangeToJavaRepo } from "../../common/listener/support/pushtest/jvm/materialChangeToJavaRepo";
 import { HasSpringBootApplicationClass } from "../../common/listener/support/pushtest/jvm/springPushTests";
 import { NamedSeedRepo } from "../../common/listener/support/pushtest/NamedSeedRepo";
@@ -98,6 +98,7 @@ import {
 import { addNodeSupport } from "../parts/stacks/nodeSupport";
 import { addSpringSupport } from "../parts/stacks/springSupport";
 import { addTeamPolicies } from "../parts/team/teamPolicies";
+import { leinBuilder } from "../../common/delivery/build/local/lein/leinBuilder";
 
 export type CloudFoundryMachineOptions = SoftwareDeliveryMachineOptions & JavaSupportOptions & DockerOptions;
 
@@ -110,6 +111,9 @@ export function cloudFoundryMachine(options: CloudFoundryMachineOptions): Softwa
     const sdm = new SoftwareDeliveryMachine(
         "CloudFoundry software delivery machine",
         options,
+        whenPushSatisfies(IsLein)
+            .itMeans("Build a Clojure library")
+            .setGoals(LibraryGoals),
         whenPushSatisfies(HasTravisFile, IsNode)
             .itMeans("Already builds with Travis")
             .setGoals(new Goals("Autofix only", AutofixGoal)),
@@ -156,6 +160,9 @@ export function cloudFoundryMachine(options: CloudFoundryMachineOptions): Softwa
         build.when(IsNode, ToDefaultBranch)
             .itMeans("Try standard node build")
             .set(runBuildBuilder),
+        build.when(IsLein)
+            .itMeans("Lein build")
+            .set(leinBuilder(options.projectLoader)),
         build.when(IsNode)
             .itMeans("Just compile")
             .set(runCompileBuilder),

--- a/test/handlers/events/delivery/build/local/lein/packageCljTest.ts
+++ b/test/handlers/events/delivery/build/local/lein/packageCljTest.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { InMemoryProject } from "@atomist/automation-client/project/mem/InMemoryProject";
 import { InMemoryFile } from "@atomist/automation-client/project/mem/InMemoryFile";
 import { projectCljToAppInfo } from "../../../../../../../src/common/delivery/build/local/lein/leinBuilder";

--- a/test/handlers/events/delivery/build/local/lein/packageCljTest.ts
+++ b/test/handlers/events/delivery/build/local/lein/packageCljTest.ts
@@ -1,0 +1,62 @@
+import { InMemoryProject } from "@atomist/automation-client/project/mem/InMemoryProject";
+import { InMemoryFile } from "@atomist/automation-client/project/mem/InMemoryFile";
+import { projectCljToAppInfo } from "../../../../../../../src/common/delivery/build/local/lein/leinBuilder";
+import * as assert from "power-assert";
+
+describe("package.clj parsing", () => {
+
+    it("should parse valid project.clj", async () => {
+        const p = InMemoryProject.of(new InMemoryFile("project.clj", Valid1));
+        const parsed = await projectCljToAppInfo(p);
+        assert.equal(parsed.name, "automation-client-clj");
+        assert.equal(parsed.version, "0.5.0");
+    });
+
+});
+
+/* tslint:disable */
+
+const Valid1 = `(defproject com.atomist/automation-client-clj "0.5.0"
+  :description "Atomist automation client implementation in Clojure"
+  :url "https://github.com/atomisthq/automation-client-clj"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.clojure/core.async "0.4.474"]
+
+                 ;; websocket
+                 [org.clojure/data.json "0.2.6"]
+                 [clj-http "3.7.0"]
+                 [stylefruits/gniazdo "1.0.1"]
+
+                 ;; util
+                 [mount "0.1.11"]
+                 [environ "1.0.0"]
+                 [diehard "0.7.0"]
+
+                 ;; logging
+                 [org.clojure/tools.logging "0.3.1"]
+                 [ch.qos.logback/logback-classic "1.1.7"]
+                 [org.slf4j/slf4j-api "1.7.21"]
+                 [io.clj/logging "0.8.1"]
+                 [com.rpl/specter "1.1.0"]]
+
+  :plugins [[lein-environ "1.1.0"]
+            [environ/environ.lein "0.3.1"]]
+
+  :min-lein-version "2.6.1" :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
+                                                              :username :env/clojars_username
+                                                              :password :env/clojars_password
+                                                              :sign-releases false}]]
+
+  :profiles {:dev {:dependencies [[org.clojure/test.check "0.9.0"]
+                                  [ring/ring-mock "0.3.0"]
+                                  [environ "1.1.0"]
+                                  [org.clojure/tools.nrepl "0.2.12"]
+                                  [org.clojure/tools.namespace "0.2.11"]]
+                   :source-paths ["env/dev/clj"]
+                   :plugins [[lein-set-version "0.4.1"]
+                             [lein-project-version "0.1.0"]]
+                   :resource-paths ["env/dev/resources"]
+                   :repl-options {:init-ns user}}})
+(defproject com.atomist/automation-client-clj "0.5.0"`;

--- a/test/handlers/events/delivery/build/local/lein/packageCljTest.ts
+++ b/test/handlers/events/delivery/build/local/lein/packageCljTest.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { InMemoryProject } from "@atomist/automation-client/project/mem/InMemoryProject";
 import { InMemoryFile } from "@atomist/automation-client/project/mem/InMemoryFile";
-import { projectCljToAppInfo } from "../../../../../../../src/common/delivery/build/local/lein/leinBuilder";
+import { InMemoryProject } from "@atomist/automation-client/project/mem/InMemoryProject";
 import * as assert from "power-assert";
+import { projectCljToAppInfo } from "../../../../../../../src/common/delivery/build/local/lein/leinBuilder";
 
 describe("package.clj parsing", () => {
 


### PR DESCRIPTION
Needs to be integrated with ArtifactStore and to parse build output to interpret it. But successfully builds `automation-client-clj`. Relies on lean being installed on automation client node.