### PR TITLE
Rolar logging for child process

### DIFF
--- a/src/common/log/RolarProgressLog.ts
+++ b/src/common/log/RolarProgressLog.ts
@@ -51,6 +51,10 @@ export class RolarProgressLog implements ProgressLog {
         return this.logPath.join("/");
     }
 
+    get url() {
+        return `${this.rolarBaseUrl}/logs/${this.name}`;
+    }
+
     public async isAvailable() {
         const url = `${this.rolarBaseUrl}/api/logs`;
         try {

--- a/src/common/log/RolarProgressLog.ts
+++ b/src/common/log/RolarProgressLog.ts
@@ -39,9 +39,13 @@ export class RolarProgressLog implements ProgressLog {
 
     private localLogs: LogData[] = [];
 
+    private lineBuffer = "";
+
     constructor(private readonly rolarBaseUrl: string,
                 private readonly logPath: string[],
+                private readonly lineDelimiter: string = null,
                 private readonly bufferSizeLimit: number = 10000,
+                private readonly logLevel: string = "info",
                 private readonly timestamper: Iterator<Date> = timestampGenerator(),
                 private readonly retryOptions: WrapOptions = {},
                 private readonly axiosInstance: AxiosInstance = axios) {
@@ -69,9 +73,18 @@ export class RolarProgressLog implements ProgressLog {
     }
 
     public write(what: string) {
+        let line = what;
+        if (this.lineDelimiter) {
+            this.lineBuffer += what;
+            if (!this.lineBuffer.endsWith(this.lineDelimiter)) {
+                return;
+            }
+            line = this.lineBuffer.slice(0, - this.lineDelimiter.length);
+            this.lineBuffer = "";
+        }
         this.localLogs.push({
-            level: "info",
-            message: what,
+            level: this.logLevel,
+            message: line,
             timestamp: this.constructUtcTimestamp(),
         } as LogData);
         const bufferSize = this.localLogs.reduce((acc, logData) => acc + logData.message.length, 0);
@@ -109,7 +122,8 @@ export class RolarProgressLog implements ProgressLog {
         return result;
     }
 
-    private constructUtcTimestamp() {
+    private constructUtcTimestamp(): string {
+        if (!this.timestamper) { return ""; }
         const now: Date = this.timestamper.next().value;
         const date = [now.getUTCMonth() + 1, now.getUTCDate(), now.getUTCFullYear()]
             .map(t => _.padStart(t.toString(), 2, "0"));

--- a/test/common/log/RolarProgressLogTest.ts
+++ b/test/common/log/RolarProgressLogTest.ts
@@ -160,7 +160,7 @@ describe("RolarProgressLog", () => {
                 const expectedRequest = [
                     {
                         level: "info",
-                        message: "He cuts down trees, he eat his lunch",
+                        message: "He cuts down trees, he eats his lunch",
                         timestamp: "01/01/1970 00:00:00.000",
                     },
                     {
@@ -174,11 +174,17 @@ describe("RolarProgressLog", () => {
                 return [200];
             });
 
-        smallBufferLog.write("He cuts down trees, he eat his lunch");
+        smallBufferLog.write("He cuts down trees, he eats his lunch");
         smallBufferLog.write("He goes to the lavatory");
         smallBufferLog.write("On Wednesdays he goes shopping and has buttered scones for tea");
 
         assert.deepEqual((smallBufferLog as any).localLogs, []);
+    });
+
+    it("should provide a link to the log", async () => {
+        const log = new RolarProgressLog("http://fakehost", ["test", "it"], 10000, fakeTimestampGenerator());
+
+        assert.equal(log.url, "http://fakehost/logs/test/it");
     });
 
 });

--- a/test/common/log/RolarProgressLogTest.ts
+++ b/test/common/log/RolarProgressLogTest.ts
@@ -30,7 +30,7 @@ describe("RolarProgressLog", () => {
 
     it("should be available if returning http 200", async () => {
         const axiosInstance = axios.create();
-        const log = new RolarProgressLog("http://fakehost", ["test"], 10000, fakeTimestampGenerator(), { retries: 0 },
+        const log = new RolarProgressLog("http://fakehost", ["test"], null, 10000, "info", fakeTimestampGenerator(), { retries: 0 },
             axiosInstance);
         const mockAxios = new MockAdapter(axiosInstance);
         mockAxios.onHead("http://fakehost/api/logs").replyOnce(200);
@@ -40,7 +40,7 @@ describe("RolarProgressLog", () => {
 
     it("should not be available if returning http 404", async () => {
         const axiosInstance = axios.create();
-        const log = new RolarProgressLog("http://fakehost", ["test"], 10000, fakeTimestampGenerator(), { retries: 0 },
+        const log = new RolarProgressLog("http://fakehost", ["test"], null, 10000, "info", fakeTimestampGenerator(), { retries: 0 },
             axiosInstance);
         const mockAxios = new MockAdapter(axiosInstance);
         mockAxios.onHead("http://fakehost/api/logs").replyOnce(404);
@@ -49,7 +49,7 @@ describe("RolarProgressLog", () => {
     });
 
     it("should write logs to memory", async () => {
-        const log = new RolarProgressLog("http://fakehost", ["test"], 10000, fakeTimestampGenerator(), { retries: 0 });
+        const log = new RolarProgressLog("http://fakehost", ["test"], null, 10000, "info", fakeTimestampGenerator());
 
         log.write("I'm a lumberjack and I'm OK");
         log.write("I sleep all night and I work all day");
@@ -70,7 +70,7 @@ describe("RolarProgressLog", () => {
 
     it("should flush logs", async () => {
         const axiosInstance = axios.create();
-        const log = new RolarProgressLog("http://fakehost", ["test"], 10000, fakeTimestampGenerator(), { retries: 0 },
+        const log = new RolarProgressLog("http://fakehost", ["test"], null, 10000, "info", fakeTimestampGenerator(), { retries: 0 },
             axiosInstance);
         const mockAxios = new MockAdapter(axiosInstance);
         mockAxios.onPost("http://fakehost/api/logs/test")
@@ -101,7 +101,7 @@ describe("RolarProgressLog", () => {
 
     it("should not clear logs if flush fails", async () => {
         const axiosInstance = axios.create();
-        const log = new RolarProgressLog("http://fakehost", ["test"], 10000, fakeTimestampGenerator(), { retries: 0 },
+        const log = new RolarProgressLog("http://fakehost", ["test"], null, 10000, "info", fakeTimestampGenerator(), { retries: 0 },
             axiosInstance);
         const mockAxios = new MockAdapter(axiosInstance);
         mockAxios.onPost("http://fakehost/api/logs/test")
@@ -127,7 +127,7 @@ describe("RolarProgressLog", () => {
 
     it("should close logs", async () => {
         const axiosInstance = axios.create();
-        const log = new RolarProgressLog("http://fakehost", ["test"], 10000, fakeTimestampGenerator(), { retries: 0 },
+        const log = new RolarProgressLog("http://fakehost", ["test"], null, 10000, "info", fakeTimestampGenerator(), { retries: 0 },
             axiosInstance);
         const mockAxios = new MockAdapter(axiosInstance);
         mockAxios.onPost("http://fakehost/api/logs/test?closed=true")
@@ -152,7 +152,7 @@ describe("RolarProgressLog", () => {
 
     it("should flush logs automatically", async () => {
         const axiosInstance = axios.create();
-        const smallBufferLog = new RolarProgressLog("http://fakehost", ["test"], 50, fakeTimestampGenerator(),
+        const smallBufferLog = new RolarProgressLog("http://fakehost", ["test"], null, 50, "info", fakeTimestampGenerator(),
             { retries: 0 }, axiosInstance);
         const mockAxios = new MockAdapter(axiosInstance);
         mockAxios.onPost("http://fakehost/api/logs/test")
@@ -182,9 +182,65 @@ describe("RolarProgressLog", () => {
     });
 
     it("should provide a link to the log", async () => {
-        const log = new RolarProgressLog("http://fakehost", ["test", "it"], 10000, fakeTimestampGenerator());
+        const log = new RolarProgressLog("http://fakehost", ["test", "it"], null, 10000, "info", fakeTimestampGenerator());
 
         assert.equal(log.url, "http://fakehost/logs/test/it");
+    });
+
+    it("should log as debug", async () => {
+        const log = new RolarProgressLog("http://fakehost", ["test"], null, 10000, "debug", fakeTimestampGenerator());
+
+        log.write("I'm a lumberjack and I'm OK");
+        log.write("I sleep all night and I work all day");
+
+        assert.deepEqual((log as any).localLogs, [
+            {
+                level: "debug",
+                message: "I'm a lumberjack and I'm OK",
+                timestamp: "01/01/1970 00:00:00.000",
+            },
+            {
+                level: "debug",
+                message: "I sleep all night and I work all day",
+                timestamp: "01/01/1970 00:00:00.001",
+            },
+        ]);
+    });
+
+    it("should log without timestamp", async () => {
+        const log = new RolarProgressLog("http://fakehost", ["test"], null, 10000, "", null);
+
+        log.write("I'm a lumberjack and I'm OK");
+        log.write("I sleep all night and I work all day");
+
+        assert.deepEqual((log as any).localLogs, [
+            {
+                level: "",
+                message: "I'm a lumberjack and I'm OK",
+                timestamp: "",
+            },
+            {
+                level: "",
+                message: "I sleep all night and I work all day",
+                timestamp: "",
+            },
+        ]);
+    });
+
+    it("should not complete line until newline", async () => {
+        const log = new RolarProgressLog("http://fakehost", ["test"], "\n", 10000, "", null);
+
+        log.write("I'm a lumberjack");
+        log.write(" and I'm");
+        log.write(" OK\n");
+
+        assert.deepEqual((log as any).localLogs, [
+            {
+                level: "",
+                message: "I'm a lumberjack and I'm OK",
+                timestamp: "",
+            },
+        ]);
     });
 
 });


### PR DESCRIPTION
Now it is possible to make the logs look as intended from a child process. With this config it leaves off the timestamp and log level and buffers the writes until a newline is encountered at the end of the message.

```
const infoLog = new RolarProgressLog("http://fakehost", ["test"], "\n", 10000, "info", null);
const errorLog = new RolarProgressLog("http://fakehost", ["test"], "\n", 10000, "error", null);
childProcess.stdout.on("data", what => infoLog.write(buffer));
childProcess.stderr.on("data", what => errorLog.write(buffer));
```