### PR TITLE
If the log is available online, don't show it

### DIFF
--- a/src/common/delivery/build/local/lein/leinBuilder.ts
+++ b/src/common/delivery/build/local/lein/leinBuilder.ts
@@ -36,7 +36,6 @@ export const leinLogInterpreter: LogInterpreter = log => {
         // We don't yet know how to interpret clojure logs
         relevantPart: undefined,
         message: "lein errors",
-        includeFullLog: true,
     };
 };
 

--- a/src/common/delivery/build/local/maven/mavenLogInterpreter.ts
+++ b/src/common/delivery/build/local/maven/mavenLogInterpreter.ts
@@ -74,7 +74,6 @@ export const MavenLogInterpreter: LogInterpreter<MavenInfo> = log => {
     return {
         relevantPart: "",
         message: "Unknown error",
-        includeFullLog: true,
         data,
     };
 };

--- a/src/common/delivery/build/local/npm/npmLogInterpreter.ts
+++ b/src/common/delivery/build/local/npm/npmLogInterpreter.ts
@@ -28,6 +28,5 @@ export const NpmLogInterpreter: LogInterpreter = log => {
     return {
         relevantPart,
         message: "npm errors",
-        includeFullLog: true,
     };
 };

--- a/src/common/delivery/deploy/local/maven/mavenSourceDeployer.ts
+++ b/src/common/delivery/deploy/local/maven/mavenSourceDeployer.ts
@@ -176,7 +176,6 @@ const springBootRunLogInterpreter: LogInterpreter = (log: string) => {
         return {
             relevantPart: maybeMavenErrors,
             message: "Maven errors",
-            includeFullLog: true,
         };
     }
 

--- a/src/common/delivery/deploy/pcf/CloudFoundryBlueGreenDeployer.ts
+++ b/src/common/delivery/deploy/pcf/CloudFoundryBlueGreenDeployer.ts
@@ -141,7 +141,6 @@ export class CloudFoundryBlueGreenDeployer implements Deployer<CloudFoundryInfo,
         return {
             relevantPart: log.split("\n").slice(-10).join("\n"),
             message: "Oh no!",
-            includeFullLog: true,
         };
    }
 }

--- a/src/common/delivery/deploy/pcf/CloudFoundryPushDeployer.ts
+++ b/src/common/delivery/deploy/pcf/CloudFoundryPushDeployer.ts
@@ -122,7 +122,6 @@ export class CloudFoundryPushDeployer implements Deployer<CloudFoundryInfo, Clou
         return {
             relevantPart: log.split("\n").slice(-10).join("\n"),
             message: "Oh no!",
-            includeFullLog: true,
         };
    }
 }

--- a/src/common/delivery/deploy/pcf/CommandLineCloudFoundryDeployer.ts
+++ b/src/common/delivery/deploy/pcf/CommandLineCloudFoundryDeployer.ts
@@ -123,7 +123,6 @@ export class CommandLineCloudFoundryDeployer implements Deployer<CloudFoundryInf
         return {
             relevantPart: "",
             message: "Deploy failed",
-            includeFullLog: true,
         };
     }
 

--- a/src/common/delivery/goals/support/logInterpreters.ts
+++ b/src/common/delivery/goals/support/logInterpreters.ts
@@ -27,7 +27,6 @@ export function lastLinesLogInterpreter(message: string, lines: number = 10): Lo
         return {
             relevantPart: log.split("\n").slice(-lines).join("\n"),
             message,
-            includeFullLog: true,
         };
     };
 }

--- a/src/util/slack/reportFailureInterpretationToLinkedChannels.ts
+++ b/src/util/slack/reportFailureInterpretationToLinkedChannels.ts
@@ -26,7 +26,7 @@ export async function reportFailureInterpretationToLinkedChannels(stepName: stri
                                                                   addressChannels: AddressChannels,
                                                                   retryButton?: slack.Action) {
     await addressChannels({
-        text: `Failed ${stepName} of ${slack.url(`${id.url}/tree/${id.sha}`, id.sha.substr(0, 6))}`,
+        text: `Failed ${stepName} of ${slack.url(`${id.url}/tree/${id.sha}`, id.sha.substr(0, 7))}`,
         attachments: [{
             title: interpretation.message || "Failure",
             title_link: fullLog.url,
@@ -36,7 +36,9 @@ export async function reportFailureInterpretationToLinkedChannels(stepName: stri
             actions: retryButton ? [retryButton] : [],
         }],
     });
-    if (interpretation.includeFullLog) {
+    const includeFullLogByDefault = !fullLog.url; // if there is no link, include it by default
+    const shouldIncludeFullLog = "includeFullLog" in interpretation ? interpretation.includeFullLog : includeFullLogByDefault;
+    if (shouldIncludeFullLog) {
         await addressChannels({
             content: fullLog.log,
             fileType: "text",

--- a/test/util/slack/reportFailureInterpretationTest.ts
+++ b/test/util/slack/reportFailureInterpretationTest.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as assert from "power-assert";
 import { AddressChannels } from "../../../src/common/slack/addressChannels";
 import { SlackMessage } from "@atomist/slack-messages";

--- a/test/util/slack/reportFailureInterpretationTest.ts
+++ b/test/util/slack/reportFailureInterpretationTest.ts
@@ -1,0 +1,91 @@
+import * as assert from "power-assert";
+import { AddressChannels } from "../../../src/common/slack/addressChannels";
+import { SlackMessage } from "@atomist/slack-messages";
+import { reportFailureInterpretationToLinkedChannels } from "../../../src/util/slack/reportFailureInterpretationToLinkedChannels";
+import { InterpretedLog } from "../../../src";
+import { RemoteRepoRef } from "@atomist/automation-client/operations/common/RepoId";
+
+describe("Reporting failure interpretation", () => {
+
+    interface AddressChannelsSpy {
+        messagesSent: SlackMessage[],
+        sentFullLog: boolean
+    }
+
+    function fakeAddressChannels(): [AddressChannels, AddressChannelsSpy] {
+        const spy: AddressChannelsSpy = {
+            messagesSent: [],
+            get sentFullLog() {
+                return !!this.messagesSent.find(m => m.fileType === "text")
+            },
+        };
+        const ac = async (msg, opts) => {
+            spy.messagesSent.push(msg);
+        };
+
+        return [ac, spy];
+    }
+
+    it("Reports the full log if requested", async () => {
+
+        const [ac, spy] = fakeAddressChannels();
+
+        const interpretedLog: InterpretedLog = {
+            relevantPart: "busted",
+            message: "Hi",
+            includeFullLog: true,
+        };
+        const fullLog = {log: "you are so busted"};
+        await reportFailureInterpretationToLinkedChannels("stepName",
+            interpretedLog, fullLog, {sha: "abc"} as RemoteRepoRef, ac);
+
+        assert(spy.sentFullLog);
+    });
+
+    it("Does not the full log if specifically unrequested", async () => {
+
+        const [ac, spy] = fakeAddressChannels();
+
+        const interpretedLog: InterpretedLog = {
+            relevantPart: "busted",
+            message: "Hi",
+            includeFullLog: false,
+        };
+        const fullLog = {url: "here", log: "you are so busted"};
+        await reportFailureInterpretationToLinkedChannels("stepName",
+            interpretedLog, fullLog, {sha: "abc"} as RemoteRepoRef, ac);
+
+        assert(!spy.sentFullLog);
+    });
+
+    it("Does not report the full log if unspecified, and the log is available at a url", async () => {
+
+        const [ac, spy] = fakeAddressChannels();
+
+        const interpretedLog: InterpretedLog = {
+            relevantPart: "busted",
+            message: "Hi",
+        };
+        const fullLog = {url: "here", log: "you are so busted"};
+        await reportFailureInterpretationToLinkedChannels("stepName",
+            interpretedLog, fullLog, {sha: "abc"} as RemoteRepoRef, ac);
+
+        assert(!spy.sentFullLog);
+    });
+
+    it("Reports the full log if unspecified, but the log does not have a url", async () => {
+
+        const [ac, spy] = fakeAddressChannels();
+
+        const interpretedLog: InterpretedLog = {
+            relevantPart: "busted",
+            message: "Hi",
+        };
+        const fullLog = {log: "you are so busted"};
+        await reportFailureInterpretationToLinkedChannels("stepName",
+            interpretedLog, fullLog, {sha: "abc"} as RemoteRepoRef, ac);
+
+        assert(spy.sentFullLog);
+    });
+
+});


### PR DESCRIPTION
This removes all the places we were saying to please show the log
Instead if the log has a URL it will skip it, and if it does not,
we will send it to Slack as a snippet.

That way if Rolar is down we'll get the log in slack by default.

the log interpreters can still explicitly include or not include it.